### PR TITLE
Hide "Attributes" from the POI tab bar when adding a new item

### DIFF
--- a/src/iOS/POITabBarController.m
+++ b/src/iOS/POITabBarController.m
@@ -42,8 +42,23 @@
 
 	NSInteger tabIndex = [[NSUserDefaults standardUserDefaults] integerForKey:@"POITabIndex"];
 	self.selectedIndex = tabIndex;
+    
+    [self updatePOIAttributesTabBarItemVisibilityWithSelectedObject:selection];
 }
 
+/**
+ Hides the POI attributes tab bar item when the user is adding a new item, since it doesn't have any attributes yet.
+
+ @param selectedObject The object that the user selected on the map.
+ */
+- (void)updatePOIAttributesTabBarItemVisibilityWithSelectedObject:(nullable OsmBaseObject *)selectedObject {
+    BOOL isAddingNewItem = selectedObject.ident.integerValue == 0;
+    if (isAddingNewItem) {
+        NSMutableArray<UIViewController *> *viewControllers = [NSMutableArray arrayWithArray:self.viewControllers];
+        [viewControllers removeLastObject];
+        [self setViewControllers:viewControllers animated:NO];
+    }
+}
 
 - (void)setFeatureKey:(NSString *)key value:(NSString *)value
 {


### PR DESCRIPTION
This branch hides the "Attributes" tab bar item (the one on the right) when the user is adding a brand-new object. At the moment, when tapping this tab bar item while adding a new item, a more or less empty view controller is visible, with some of the fields even saying "0".

By hiding the item, we're limiting the mistakes that the user can make, improving the usability.