### PR TITLE
Remove unused forward declaration for missing class `MapCSS`

### DIFF
--- a/src/Shared/EditorMapLayer.h
+++ b/src/Shared/EditorMapLayer.h
@@ -14,7 +14,6 @@
 @class Buildings3DView;
 @class OsmMapData;
 @class OsmRenderInfo;
-@class MapCSS;
 @class MapView;
 @class OsmBaseObject;
 @class OsmNode;
@@ -35,7 +34,6 @@ extern const double MinIconSizeInPixels;
 	CGSize					_iconSize;
 	double					_highwayScale;
 
-	MapCSS				*	_mapCss;
 	NSMutableSet		*	_nameDrawSet;
 
 	NSMutableArray		*	_shownObjects;


### PR DESCRIPTION
The class does not exist, so there's no need to keep this.