### PR TITLE
Add IDEWorkspaceChecks.plist

### DIFF
--- a/src/iOS/Go Map!!.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/src/iOS/Go Map!!.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
As per the [Xcode Release Notes][1]:
> Xcode 9.3 adds a new IDEWorkspaceChecks.plist file to a workspace's shared data,
> to store the state of necessary workspace checks.
> Committing this file to source control will prevent unnecessary rerunning
> of those checks for each user opening the workspace. (37293167)

[1]: https://developer.apple.com/library/archive/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-DontLinkElementID_31