### PR TITLE
Fix: Make links in "Help" view controller tapable

### DIFF
--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -2913,10 +2913,10 @@ Cg
                                         </attributes>
                                     </fragment>
                                     <fragment>
-                                        <string key="content">Tags are used to describe objects in the OpenStreetMap database, such as indicating that a location contains a shop or restaurant and what it's name is. To select an existing object, either a node or a way, simply tap it. To select a building you must select a wall rather than the center. Selected objects are highlighted in yellow and display a title (gray box) and a configuration button (blue triangle). Press the configuration button to view and edit tags. 
+                                        <mutableString key="content">Tags are used to describe objects in the OpenStreetMap database, such as indicating that a location contains a shop or restaurant and what it's name is. To select an existing object, either a node or a way, simply tap it. To select a building you must select a wall rather than the center. Selected objects are highlighted in yellow and display a title (gray box) and a configuration button (blue triangle). Press the configuration button to view and edit tags. 
 The tag editing screen presented has three tabs of views. The first view (Common Tags) presents fields for adding common points of interest. The second tab screen allows advanced users to add arbitrary tags and values.
 The third tab screen shows metadata about the object: who created it and when, and additional low-level details. From this screen you can also drill down to information stored on the OSM server about the user, change set, object history, and object details:
-</string>
+</mutableString>
                                         <attributes>
                                             <font key="NSFont" size="14" name="Helvetica"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="leftToRight" paragraphSpacing="12" defaultTabInterval="36">
@@ -3005,8 +3005,8 @@ Cg
                                         </attributes>
                                     </fragment>
                                     <fragment>
-                                        <string key="content">If you wish to add nodes to a way there are two approaches, depending on whether you are adding the node to the middle of the way or extending it at either end. To add a node to the middle of a way: Select the way by tapping close to the position where you want the new node to appear, then press "+". A node will be added at the selected location. To append a node to the end of a way first select the way, then select a node at either end, then press "+". A new node will be added to the start or end of the way.
-</string>
+                                        <mutableString key="content">If you wish to add nodes to a way there are two approaches, depending on whether you are adding the node to the middle of the way or extending it at either end. To add a node to the middle of a way: Select the way by tapping close to the position where you want the new node to appear, then press "+". A node will be added at the selected location. To append a node to the end of a way first select the way, then select a node at either end, then press "+". A new node will be added to the start or end of the way.
+</mutableString>
                                         <attributes>
                                             <font key="NSFont" size="14" name="Helvetica"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="leftToRight" paragraphSpacing="12" defaultTabInterval="36">
@@ -3121,9 +3121,9 @@ Cg
                                         </attributes>
                                     </fragment>
                                     <fragment>
-                                        <string key="content">When you are finished making your changes to the map you can submit your changes to the OpenStreetMap server by pressing the upload (cloud) button. If the change is uploaded successfully you will simply be returned to the map screen. After uploading you cannot undo to a previous state; all changes are final. If your upload fails because of a version conflict or other reason you can email the OSM change file ("osmChange.osc") to yourself to fix the problems offline.
+                                        <mutableString key="content">When you are finished making your changes to the map you can submit your changes to the OpenStreetMap server by pressing the upload (cloud) button. If the change is uploaded successfully you will simply be returned to the map screen. After uploading you cannot undo to a previous state; all changes are final. If your upload fails because of a version conflict or other reason you can email the OSM change file ("osmChange.osc") to yourself to fix the problems offline.
 You must have a username and password registered at www.openstreetmap.org to upload changes, and have your username and password configured on the Settings|Credentials screen.
-</string>
+</mutableString>
                                         <attributes>
                                             <font key="NSFont" size="14" name="Helvetica"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="leftToRight" paragraphSpacing="12" defaultTabInterval="36">
@@ -3270,27 +3270,7 @@ This privacy policy governs your use of the software application </string>
                                             </paragraphStyle>
                                         </attributes>
                                     </fragment>
-                                    <fragment content=" for mobile devices that was created by ">
-                                        <attributes>
-                                            <font key="NSFont" size="14" name="Helvetica"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="leftToRight" paragraphSpacing="12" defaultTabInterval="36">
-                                                <tabStops/>
-                                            </paragraphStyle>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="Bryce Cogswell">
-                                        <attributes>
-                                            <color key="NSColor" red="0.0" green="0.0" blue="0.9137254901960784" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            <font key="NSFont" size="14" name="Helvetica"/>
-                                            <url key="NSLink" string="http://www.openstreetmap.org/user/bryceco/diary"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="leftToRight" paragraphSpacing="12" defaultTabInterval="36">
-                                                <tabStops/>
-                                            </paragraphStyle>
-                                            <integer key="NSUnderline" value="1"/>
-                                            <color key="NSUnderlineColor" red="0.0" green="0.0" blue="0.9137254901960784" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=". ">
+                                    <fragment content=" for mobile devices that was created by Bryce Cogswell (https://www.openstreetmap.org/user/bryceco/diary). ">
                                         <attributes>
                                             <font key="NSFont" size="14" name="Helvetica"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="leftToRight" paragraphSpacing="12" defaultTabInterval="36">
@@ -3361,28 +3341,8 @@ The data you edit and upload to openstreetmap.org using </string>
                                             </paragraphStyle>
                                         </attributes>
                                     </fragment>
-                                    <fragment content=" is subject to the OpenStreetMap ">
-                                        <attributes>
-                                            <font key="NSFont" size="14" name="Helvetica"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="leftToRight" paragraphSpacing="12" defaultTabInterval="36">
-                                                <tabStops/>
-                                            </paragraphStyle>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="Privacy Policy">
-                                        <attributes>
-                                            <color key="NSColor" red="0.0" green="0.0" blue="0.9137254901960784" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            <font key="NSFont" size="14" name="Helvetica"/>
-                                            <url key="NSLink" string="http://wiki.openstreetmap.org/wiki/Privacy_Policy"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="leftToRight" paragraphSpacing="12" defaultTabInterval="36">
-                                                <tabStops/>
-                                            </paragraphStyle>
-                                            <integer key="NSUnderline" value="1"/>
-                                            <color key="NSUnderlineColor" red="0.0" green="0.0" blue="0.9137254901960784" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </attributes>
-                                    </fragment>
                                     <fragment>
-                                        <string key="content">.
+                                        <string key="content"> is subject to the OpenStreetMap Privacy Policy (https://wiki.osmfoundation.org/wiki/Privacy_Policy).
 </string>
                                         <attributes>
                                             <font key="NSFont" size="14" name="Helvetica"/>

--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -3464,6 +3464,7 @@ This Privacy Policy may be updated from time to time for any reason. We will not
                                     </fragment>
                                 </attributedString>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                <dataDetectorType key="dataDetectorTypes" link="YES"/>
                             </textView>
                             <navigationBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="at5-53-Fcu">
                                 <rect key="frame" x="0.0" y="20" width="320" height="44"/>


### PR DESCRIPTION
This replaces the "inline" links with complete URLs in braces. By enabling the "Link" data detector, the links can be tapped, which opens them in Safari.