### PR TITLE
Remove a lot of warnings by moving property `previousDiscardDate` to private interface

### DIFF
--- a/src/Shared/OsmMapData.h
+++ b/src/Shared/OsmMapData.h
@@ -68,8 +68,6 @@ typedef OsmNode   * (^EditActionReturnNode)(void);
 @property (copy,nonatomic)	NSString *	credentialsPassword;
 
 @property (readonly,nonatomic)	NetworkStatus	*	serverNetworkStatus;
-@property (readonly,nonnull)	NSDate			*	previousDiscardDate;
-
 
 +(void)setEditorMapLayerForArchive:(EditorMapLayer *)editorLayer; // only used when saving/restoring undo manager
 +(EditorMapLayer *)editorMapLayerForArchive; // only used when saving/restoring undo manager

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -50,6 +50,12 @@ NSString * OSM_API_URL;
 
 #pragma mark OsmMapData
 
+@interface OsmMapData ()
+
+@property (readonly,nonnull)    NSDate *            previousDiscardDate;
+
+@end
+
 @implementation OsmMapData
 
 static EditorMapLayer * g_EditorMapLayerForArchive = nil;


### PR DESCRIPTION
Since the property is is only accessed in the implementation file, we don't need
to have it publicly available.

In addition, doing this gets rid of a lot of warnings that were caused by the
`nonnull`, and the rest of the (public) interface lacking the nullability specifiers.

This is the MVP approach to silence those warnings. Ideally, we would
audit the whole file for nullability, but that takes more time.