### PR TITLE
Enable users to "Open Settings" when location access is denied

### DIFF
--- a/src/Shared/MapView.m
+++ b/src/Shared/MapView.m
@@ -1447,7 +1447,24 @@ static inline ViewOverlayMask OverlaysFor(MapViewState state, ViewOverlayMask ma
 		if ( status == kCLAuthorizationStatusRestricted || status == kCLAuthorizationStatusDenied ) {
 			NSString * appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
 			NSString * title = [NSString stringWithFormat:NSLocalizedString(@"Turn On Location Services to Allow %@ to Determine Your Location",nil),appName];
-			[self showAlert:title message:nil];
+            
+            UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title
+                                                                                     message:nil
+                                                                              preferredStyle:UIAlertControllerStyleAlert];
+            UIAlertAction *okayAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"OK",nil)
+                                                                 style:UIAlertActionStyleCancel
+                                                               handler:nil];
+            UIAlertAction *openSettings = [UIAlertAction actionWithTitle:NSLocalizedString(@"Open Settings",nil)
+                                                                 style:UIAlertActionStyleDefault
+                                                                 handler:^(UIAlertAction * _Nonnull action) {
+                                                                     [self openAppSettings];
+                                                                 }];
+            
+            [alertController addAction:openSettings];
+            [alertController addAction:okayAction];
+            
+            [self.viewController presentViewController:alertController animated:YES completion:nil];
+            
 			self.gpsState = GPS_STATE_NONE;
 			return;
 		}
@@ -1471,6 +1488,13 @@ static inline ViewOverlayMask OverlaysFor(MapViewState state, ViewOverlayMask ma
 		[_locationBallLayer removeFromSuperlayer];
 		_locationBallLayer = nil;
 	}
+}
+
+- (void)openAppSettings {
+    NSURL *openSettingsURL = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
+    if (openSettingsURL) {
+        [[UIApplication sharedApplication] openURL:openSettingsURL];
+    }
 }
 
 -(IBAction)centerOnGPS:(id)sender

--- a/src/Shared/MapView.m
+++ b/src/Shared/MapView.m
@@ -1445,25 +1445,7 @@ static inline ViewOverlayMask OverlaysFor(MapViewState state, ViewOverlayMask ma
 		
 		CLAuthorizationStatus status = [CLLocationManager authorizationStatus];
 		if ( status == kCLAuthorizationStatusRestricted || status == kCLAuthorizationStatusDenied ) {
-			NSString * appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
-			NSString * title = [NSString stringWithFormat:NSLocalizedString(@"Turn On Location Services to Allow %@ to Determine Your Location",nil),appName];
-            
-            UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title
-                                                                                     message:nil
-                                                                              preferredStyle:UIAlertControllerStyleAlert];
-            UIAlertAction *okayAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"OK",nil)
-                                                                 style:UIAlertActionStyleCancel
-                                                               handler:nil];
-            UIAlertAction *openSettings = [UIAlertAction actionWithTitle:NSLocalizedString(@"Open Settings",nil)
-                                                                 style:UIAlertActionStyleDefault
-                                                                 handler:^(UIAlertAction * _Nonnull action) {
-                                                                     [self openAppSettings];
-                                                                 }];
-            
-            [alertController addAction:openSettings];
-            [alertController addAction:okayAction];
-            
-            [self.viewController presentViewController:alertController animated:YES completion:nil];
+            [self askUserToAllowLocationAccess];
             
 			self.gpsState = GPS_STATE_NONE;
 			return;
@@ -1488,6 +1470,28 @@ static inline ViewOverlayMask OverlaysFor(MapViewState state, ViewOverlayMask ma
 		[_locationBallLayer removeFromSuperlayer];
 		_locationBallLayer = nil;
 	}
+}
+
+- (void)askUserToAllowLocationAccess {
+    NSString * appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+    NSString * title = [NSString stringWithFormat:NSLocalizedString(@"Turn On Location Services to Allow %@ to Determine Your Location",nil),appName];
+    
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title
+                                                                             message:nil
+                                                                      preferredStyle:UIAlertControllerStyleAlert];
+    UIAlertAction *okayAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"OK",nil)
+                                                         style:UIAlertActionStyleCancel
+                                                       handler:nil];
+    UIAlertAction *openSettings = [UIAlertAction actionWithTitle:NSLocalizedString(@"Open Settings",nil)
+                                                           style:UIAlertActionStyleDefault
+                                                         handler:^(UIAlertAction * _Nonnull action) {
+                                                             [self openAppSettings];
+                                                         }];
+    
+    [alertController addAction:openSettings];
+    [alertController addAction:okayAction];
+    
+    [self.viewController presentViewController:alertController animated:YES completion:nil];
 }
 
 - (void)openAppSettings {


### PR DESCRIPTION
This branch adds an "Open Settings" action to the alert that is presented when the app doesn't have the permission to access the device location. Choosing this action opens the Settings page of the application, allowing the user to easily change the location permission.

Here's a screenshot of the alert controller in action:

![Screenshot of the alert controller](https://user-images.githubusercontent.com/1681085/55511546-6138de00-5650-11e9-9f31-1a2528800455.png)
