### PR TITLE
Fix: Use the help button's size to determine its corner radius

### DIFF
--- a/src/Shared/MapView.m
+++ b/src/Shared/MapView.m
@@ -338,7 +338,7 @@ static const CGFloat Z_FLASH			= 110;
 	_notesViewDict			= [NSMutableDictionary new];
 
 	// make help button have rounded corners
-	_helpButton.layer.cornerRadius = 10.0;
+	_helpButton.layer.cornerRadius = _helpButton.bounds.size.width / 2;
 
 	// observe changes to aerial visibility so we can show/hide bing logo
 	[_aerialLayer addObserver:self forKeyPath:@"hidden" options:NSKeyValueObservingOptionNew context:NULL];


### PR DESCRIPTION
This makes sure that the button is perfectly round and doesn't look cut off. Comparison:

![1-old](https://user-images.githubusercontent.com/1681085/55670517-e56bab00-5874-11e9-8436-1762c7b40d7e.png)
![2-new](https://user-images.githubusercontent.com/1681085/55670518-e6044180-5874-11e9-923a-248e27ad8254.png)
