### PR TITLE
Fix: Use proper `cornerRadius` for edit control to remove black corners

### DIFF
--- a/src/Shared/MapView.m
+++ b/src/Shared/MapView.m
@@ -86,6 +86,7 @@ static const CGFloat Z_FLASH			= 110;
 @synthesize viewState			= _viewState;
 @synthesize screenFromMapTransform	= _screenFromMapTransform;
 
+const CGFloat kEditControlCornerRadius = 4;
 
 #pragma mark initialization
 
@@ -316,6 +317,7 @@ static const CGFloat Z_FLASH			= 110;
 	[_editControl setTitleTextAttributes:@{ NSFontAttributeName : [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline] }
 									   forState:UIControlStateNormal];
 	_editControl.layer.zPosition = Z_TOOLBAR;
+    _editControl.layer.cornerRadius = kEditControlCornerRadius;
 
 	// long press for selecting from multiple objects
 	UILongPressGestureRecognizer * longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPressGesture:)];


### PR DESCRIPTION
By setting this "magic number" corner radius, the black corners are no longer visible.

Visual comparison:

![01-old](https://user-images.githubusercontent.com/1681085/55670737-96734500-5877-11e9-8136-bf97b1722abb.png)
![02-new](https://user-images.githubusercontent.com/1681085/55670738-96734500-5877-11e9-9128-4235939f5607.png)
