### PR TITLE
Fix: Disable user interaction for `value` text field of node attributes

### DIFF
--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -3611,7 +3611,7 @@ This Privacy Policy may be updated from time to time for any reason. We will not
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </label>
-                                        <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="value" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="hfr-Mf-ZHv">
+                                        <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="value" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="hfr-Mf-ZHv">
                                             <rect key="frame" x="124" y="11.5" width="165" height="21"/>
                                             <nil key="textColor"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>

--- a/src/iOS/POIAttributesViewController.m
+++ b/src/iOS/POIAttributesViewController.m
@@ -34,6 +34,8 @@ enum {
 
 @implementation POIAttributesViewController
 
+const NSInteger kCoordinateSection = 1;
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];
@@ -121,7 +123,7 @@ enum {
 				assert(NO);
 		}
 
-	} else {
+	} else if (indexPath.section == kCoordinateSection) {
 
 		if ( object.isNode ) {
 			OsmNode * node = object.isNode;

--- a/src/iOS/POIAttributesViewController.m
+++ b/src/iOS/POIAttributesViewController.m
@@ -210,6 +210,34 @@ const NSInteger kCoordinateSection = 1;
 	[super prepareForSegue:segue sender:sender];
 }
 
+- (BOOL)tableView:(UITableView *)tableView shouldShowMenuForRowAtIndexPath:(NSIndexPath *)indexPath {
+    // Allow the user to copy the latitude/longitude.
+    return indexPath.section == kCoordinateSection;
+}
+
+- (BOOL)tableView:(UITableView *)tableView canPerformAction:(SEL)action forRowAtIndexPath:(NSIndexPath *)indexPath withSender:(id)sender {
+    if (indexPath.section == kCoordinateSection && action == @selector(copy:)) {
+        // Allow users to copy latitude/longitude.
+        return YES;
+    }
+    
+    return NO;
+}
+
+- (void)tableView:(UITableView *)tableView performAction:(SEL)action forRowAtIndexPath:(NSIndexPath *)indexPath withSender:(id)sender {
+    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+    if (![cell isKindOfClass:[AttributeCustomCell class]]) {
+        // For cells other than `AttributeCustomCell`, we don't know how to get the value.
+        return;
+    }
+    
+    AttributeCustomCell *customCell = (AttributeCustomCell *)cell;
+    
+    if (indexPath.section == kCoordinateSection && action == @selector(copy:)) {
+        [UIPasteboard.generalPasteboard setString:customCell.value.text];
+    }
+}
+
 -(IBAction)cancel:(id)sender
 {
 	[self dismissViewControllerAnimated:YES completion:nil];


### PR DESCRIPTION
There's no need to have the user interact with these values.

Disabling user interaction furthermore improves the usability, since the user
doesn't need to tap on the disclosure indicator anymore, but can use the whole cell.