### PR TITLE
Fix: Hide empty "Relations" section in tag list

### DIFF
--- a/src/iOS/POIAllTagsViewController.m
+++ b/src/iOS/POIAllTagsViewController.m
@@ -132,8 +132,10 @@
 	POITabBarController * tabController = (id)self.tabBarController;
     if (tabController.selection.isRelation) {
 		return 3;
+    } else if (_relations.count > 0) {
+        return 2;
     } else {
-		return 2;
+        return 1;
     }
 }
 

--- a/src/iOS/POIAllTagsViewController.m
+++ b/src/iOS/POIAllTagsViewController.m
@@ -130,10 +130,11 @@
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
 {
 	POITabBarController * tabController = (id)self.tabBarController;
-	if ( tabController.selection.isRelation )
+    if (tabController.selection.isRelation) {
 		return 3;
-	else
+    } else {
 		return 2;
+    }
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section


### PR DESCRIPTION
This branch makes sure to only show the "Relations" section in the "Node tags" view if there were actually any relations.