### PR TITLE
Fix: End editing when tapping "Cancel" bar button item in the "Node tags"

### DIFF
--- a/src/iOS/POIAllTagsViewController.m
+++ b/src/iOS/POIAllTagsViewController.m
@@ -415,6 +415,8 @@
 
 -(IBAction)cancel:(id)sender
 {
+    [self.view endEditing:YES];
+    
 	[self dismissViewControllerAnimated:YES completion:nil];
 }
 


### PR DESCRIPTION
This dismisses the keyboard a little bit earlier, making sure it is no longer visible when the user is back on the map.