### PR TITLE
Handle missing camera permission when measuring height

### DIFF
--- a/src/Shared/MapView.m
+++ b/src/Shared/MapView.m
@@ -3670,12 +3670,12 @@ static NSString * const DisplayLinkPanning	= @"Panning";
 }
 
 - (void)presentViewControllerForMeasuringHeight {
-    if ( self.gpsState != GPS_STATE_NONE ) {
-        [self.viewController performSegueWithIdentifier:@"CalculateHeightSegue" sender:nil];
-    } else {
+    if ( self.gpsState == GPS_STATE_NONE ) {
         NSString *errorMessage = NSLocalizedString(@"This action requires GPS to be turned on",nil);
         
         [self showAlert:errorMessage message:nil];
+    } else {
+        [self.viewController performSegueWithIdentifier:@"CalculateHeightSegue" sender:nil];
     }
 }
 

--- a/src/Shared/MapView.m
+++ b/src/Shared/MapView.m
@@ -3678,6 +3678,11 @@ static NSString * const DisplayLinkPanning	= @"Panning";
         NSString *errorMessage = NSLocalizedString(@"This action requires GPS to be turned on",nil);
         
         [self showAlert:errorMessage message:nil];
+    } else if ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo] == AVAuthorizationStatusDenied) {
+        NSString *title = NSLocalizedString(@"Unable to access the camera", "");
+        NSString *message = NSLocalizedString(@"In order to measure height, please enable camera access in the app's settings.", "");
+        
+        [self askUserToOpenSettingsWithAlertTitle:title message:message];
     } else {
         [self.viewController performSegueWithIdentifier:@"CalculateHeightSegue" sender:nil];
     }

--- a/src/Shared/MapView.m
+++ b/src/Shared/MapView.m
@@ -1478,12 +1478,12 @@ static inline ViewOverlayMask OverlaysFor(MapViewState state, ViewOverlayMask ma
     NSString * appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
     NSString * title = [NSString stringWithFormat:NSLocalizedString(@"Turn On Location Services to Allow %@ to Determine Your Location",nil),appName];
     
-    [self askUserToOpenSettingsWithAlertTitle:title];
+    [self askUserToOpenSettingsWithAlertTitle:title message:nil];
 }
 
-- (void)askUserToOpenSettingsWithAlertTitle:(NSString *)title {
+- (void)askUserToOpenSettingsWithAlertTitle:(NSString *)title message:(NSString *)message {
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title
-                                                                             message:nil
+                                                                             message:message
                                                                       preferredStyle:UIAlertControllerStyleAlert];
     UIAlertAction *okayAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"OK",nil)
                                                          style:UIAlertActionStyleCancel

--- a/src/Shared/MapView.m
+++ b/src/Shared/MapView.m
@@ -1478,6 +1478,10 @@ static inline ViewOverlayMask OverlaysFor(MapViewState state, ViewOverlayMask ma
     NSString * appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
     NSString * title = [NSString stringWithFormat:NSLocalizedString(@"Turn On Location Services to Allow %@ to Determine Your Location",nil),appName];
     
+    [self askUserToOpenSettingsWithAlertTitle:title];
+}
+
+- (void)askUserToOpenSettingsWithAlertTitle:(NSString *)title {
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title
                                                                              message:nil
                                                                       preferredStyle:UIAlertControllerStyleAlert];

--- a/src/Shared/MapView.m
+++ b/src/Shared/MapView.m
@@ -2350,11 +2350,7 @@ NSString * ActionTitle( EDIT_ACTION action, BOOL abbrev )
 			}
 			break;
 		case ACTION_HEIGHT:
-			if ( self.gpsState != GPS_STATE_NONE ) {
-				[self.viewController performSegueWithIdentifier:@"CalculateHeightSegue" sender:nil];
-			} else {
-				error = NSLocalizedString(@"This action requires GPS to be turned on",nil);
-			}
+            [self presentViewControllerForMeasuringHeight];
 			break;
 		case ACTION_EDITTAGS:
 			[self presentTagEditor:nil];
@@ -3671,6 +3667,16 @@ static NSString * const DisplayLinkPanning	= @"Panning";
 			_confirmDrag = (_editorLayer.selectedPrimary.modifyCount == 0);
 		}
 	}
+}
+
+- (void)presentViewControllerForMeasuringHeight {
+    if ( self.gpsState != GPS_STATE_NONE ) {
+        [self.viewController performSegueWithIdentifier:@"CalculateHeightSegue" sender:nil];
+    } else {
+        NSString *errorMessage = NSLocalizedString(@"This action requires GPS to be turned on",nil);
+        
+        [self showAlert:errorMessage message:nil];
+    }
 }
 
 @end


### PR DESCRIPTION
This branch will display an `UIAlertController` asking the user to allow camera access when attempting to execute the `ACTION_HEIGHT`:

![ask-for-camera-access](https://user-images.githubusercontent.com/1681085/55683698-1b229980-5932-11e9-977c-294c82d88ab4.jpeg)

This prevents a black `HeightViewController` from being presented.