### PR TITLE
Fix: Only hide `POIAttributesViewController`, not the other view controllers

### DIFF
--- a/src/iOS/POITabBarController.m
+++ b/src/iOS/POITabBarController.m
@@ -13,7 +13,7 @@
 #import "OsmObjects.h"
 #import "POICommonTagsViewController.h"
 #import "POITabBarController.h"
-
+#import "POIAttributesViewController.h"
 
 @implementation POITabBarController
 
@@ -54,9 +54,20 @@
 - (void)updatePOIAttributesTabBarItemVisibilityWithSelectedObject:(nullable OsmBaseObject *)selectedObject {
     BOOL isAddingNewItem = selectedObject.ident.integerValue <= 0;
     if (isAddingNewItem) {
-        NSMutableArray<UIViewController *> *viewControllers = [NSMutableArray arrayWithArray:self.viewControllers];
-        [viewControllers removeLastObject];
-        [self setViewControllers:viewControllers animated:NO];
+        // Remove the `POIAttributesViewController`.
+        NSMutableArray<UIViewController *> *viewControllersToKeep = [NSMutableArray array];
+        [self.viewControllers enumerateObjectsUsingBlock:^(__kindof UIViewController * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+            
+            if ([obj isKindOfClass:[UINavigationController class]] && [[(UINavigationController *)obj viewControllers].firstObject isKindOfClass:[POIAttributesViewController class]]) {
+                // For new objects, the navigation controller that contains the view controller
+                // for POI attributes is not needed; ignore it.
+                return;
+            } else {
+                [viewControllersToKeep addObject:obj];
+            }
+        }];
+        
+        [self setViewControllers:viewControllersToKeep animated:NO];
     }
 }
 


### PR DESCRIPTION
This prevents a bug that, one after another, removes all tab bar items as soon as the tab bar becomes visible again.

It's wrong to _always remove the last_. Instead, this commit makes sure to only remove view controllers from the tab bar that are `UINavigationController`s that contain the `POIAttributesViewController`.