### PR TITLE
Fix: Fix presentation of navigation bars and modal view controllers

### DIFF
--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Fx1-V2-8uJ">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Fx1-V2-8uJ">
     <device id="retina3_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment version="2304" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -2121,14 +2121,14 @@ Clear the Mapnik or Overlay tile caches  to download the latest tiles that refle
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Clear GPS Overlay Tiles" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="klC-Oh-Oyd">
-                                                    <rect key="frame" x="16" y="3" width="187.5" height="20.5"/>
+                                                    <rect key="frame" x="15" y="3" width="187.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </label>
                                                 <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Subtitle" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UT3-uR-YpN">
-                                                    <rect key="frame" x="16" y="23.5" width="53" height="18"/>
+                                                    <rect key="frame" x="15" y="23.5" width="53" height="18"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                     <color key="textColor" red="0.50196078430000002" green="0.50196078430000002" blue="0.50196078430000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -2921,10 +2921,10 @@ Cg
                                         </attributes>
                                     </fragment>
                                     <fragment>
-                                        <mutableString key="content">Tags are used to describe objects in the OpenStreetMap database, such as indicating that a location contains a shop or restaurant and what it's name is. To select an existing object, either a node or a way, simply tap it. To select a building you must select a wall rather than the center. Selected objects are highlighted in yellow and display a title (gray box) and a configuration button (blue triangle). Press the configuration button to view and edit tags. 
+                                        <string key="content">Tags are used to describe objects in the OpenStreetMap database, such as indicating that a location contains a shop or restaurant and what it's name is. To select an existing object, either a node or a way, simply tap it. To select a building you must select a wall rather than the center. Selected objects are highlighted in yellow and display a title (gray box) and a configuration button (blue triangle). Press the configuration button to view and edit tags. 
 The tag editing screen presented has three tabs of views. The first view (Common Tags) presents fields for adding common points of interest. The second tab screen allows advanced users to add arbitrary tags and values.
 The third tab screen shows metadata about the object: who created it and when, and additional low-level details. From this screen you can also drill down to information stored on the OSM server about the user, change set, object history, and object details:
-</mutableString>
+</string>
                                         <attributes>
                                             <font key="NSFont" size="14" name="Helvetica"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="leftToRight" paragraphSpacing="12" defaultTabInterval="36">
@@ -3013,8 +3013,8 @@ Cg
                                         </attributes>
                                     </fragment>
                                     <fragment>
-                                        <mutableString key="content">If you wish to add nodes to a way there are two approaches, depending on whether you are adding the node to the middle of the way or extending it at either end. To add a node to the middle of a way: Select the way by tapping close to the position where you want the new node to appear, then press "+". A node will be added at the selected location. To append a node to the end of a way first select the way, then select a node at either end, then press "+". A new node will be added to the start or end of the way.
-</mutableString>
+                                        <string key="content">If you wish to add nodes to a way there are two approaches, depending on whether you are adding the node to the middle of the way or extending it at either end. To add a node to the middle of a way: Select the way by tapping close to the position where you want the new node to appear, then press "+". A node will be added at the selected location. To append a node to the end of a way first select the way, then select a node at either end, then press "+". A new node will be added to the start or end of the way.
+</string>
                                         <attributes>
                                             <font key="NSFont" size="14" name="Helvetica"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="leftToRight" paragraphSpacing="12" defaultTabInterval="36">
@@ -3129,9 +3129,9 @@ Cg
                                         </attributes>
                                     </fragment>
                                     <fragment>
-                                        <mutableString key="content">When you are finished making your changes to the map you can submit your changes to the OpenStreetMap server by pressing the upload (cloud) button. If the change is uploaded successfully you will simply be returned to the map screen. After uploading you cannot undo to a previous state; all changes are final. If your upload fails because of a version conflict or other reason you can email the OSM change file ("osmChange.osc") to yourself to fix the problems offline.
+                                        <string key="content">When you are finished making your changes to the map you can submit your changes to the OpenStreetMap server by pressing the upload (cloud) button. If the change is uploaded successfully you will simply be returned to the map screen. After uploading you cannot undo to a previous state; all changes are final. If your upload fails because of a version conflict or other reason you can email the OSM change file ("osmChange.osc") to yourself to fix the problems offline.
 You must have a username and password registered at www.openstreetmap.org to upload changes, and have your username and password configured on the Settings|Credentials screen.
-</mutableString>
+</string>
                                         <attributes>
                                             <font key="NSFont" size="14" name="Helvetica"/>
                                             <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="leftToRight" paragraphSpacing="12" defaultTabInterval="36">
@@ -3813,7 +3813,7 @@ This Privacy Policy may be updated from time to time for any reason. We will not
                 <navigationController id="Fx1-V2-8uJ" customClass="RotatingNavigationController" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="y5O-uv-8Kt">
-                        <rect key="frame" x="0.0" y="20" width="320" height="50"/>
+                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -1547,7 +1547,7 @@
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="DRB-XW-UOn" firstAttribute="bottom" secondItem="gog-wr-wAd" secondAttribute="bottom" id="4Vi-cw-zUc"/>
+                            <constraint firstItem="DRB-XW-UOn" firstAttribute="bottom" secondItem="iDL-ho-g1h" secondAttribute="bottom" id="4Vi-cw-zUc"/>
                             <constraint firstItem="DRB-XW-UOn" firstAttribute="leading" secondItem="gog-wr-wAd" secondAttribute="leading" id="GMA-z8-Au9"/>
                             <constraint firstItem="DRB-XW-UOn" firstAttribute="top" secondItem="gog-wr-wAd" secondAttribute="top" id="J6W-fa-HO8"/>
                             <constraint firstItem="gog-wr-wAd" firstAttribute="trailing" secondItem="DRB-XW-UOn" secondAttribute="trailing" id="aLK-Zt-rkq"/>

--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -237,11 +237,11 @@
                         <outlet property="_uploadButton" destination="ma4-oI-tBL" id="wVI-LB-h9R"/>
                         <outlet property="locationButton" destination="e3U-Im-GKP" id="LSh-pS-Mw5"/>
                         <outlet property="mapView" destination="fss-Ag-fKJ" id="dCu-lv-5cU"/>
-                        <segue destination="siu-I6-IEp" kind="modal" identifier="searchSegue" id="iXU-B0-fRW"/>
                         <segue destination="f5t-25-IXF" kind="modal" identifier="poiSegue" id="OEI-9h-7td"/>
                         <segue destination="S30-cU-QcE" kind="modal" identifier="NotesSegue" id="gMc-ga-KGQ"/>
                         <segue destination="Fhw-zr-ueA" kind="modal" identifier="CalculateHeightSegue" id="Tzh-5J-H7G"/>
                         <segue destination="DCR-m3-Qgc" kind="modal" identifier="BingMetadataSegue" id="OSh-Rq-XOM"/>
+                        <segue destination="TCa-h6-J4b" kind="modal" identifier="searchSegue" id="RuH-7x-qpi"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="10" sceneMemberID="firstResponder"/>
@@ -3675,26 +3675,14 @@ This Privacy Policy may be updated from time to time for any reason. We will not
             </objects>
             <point key="canvasLocation" x="1508" y="-1584"/>
         </scene>
-        <!--Nominatum View Controller-->
+        <!--Search for Location-->
         <scene sceneID="nhJ-xs-noU">
             <objects>
-                <viewController id="siu-I6-IEp" customClass="NominatumViewController" sceneMemberID="viewController">
+                <viewController title="Search for Location" id="siu-I6-IEp" customClass="NominatumViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="SQe-Tw-wQG">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jyC-G0-Vbc">
-                                <rect key="frame" x="0.0" y="20" width="320" height="44"/>
-                                <items>
-                                    <navigationItem title="Search for Location" id="Bfb-FI-LQK">
-                                        <barButtonItem key="rightBarButtonItem" systemItem="cancel" id="1Lg-Le-97T">
-                                            <connections>
-                                                <action selector="cancel:" destination="siu-I6-IEp" id="JLa-m4-1ei"/>
-                                            </connections>
-                                        </barButtonItem>
-                                    </navigationItem>
-                                </items>
-                            </navigationBar>
                             <searchBar contentMode="redraw" placeholder="Niagara Falls" translatesAutoresizingMaskIntoConstraints="NO" id="xw9-Ro-Fai">
                                 <rect key="frame" x="0.0" y="64" width="320" height="56"/>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no"/>
@@ -3737,19 +3725,23 @@ This Privacy Policy may be updated from time to time for any reason. We will not
                         <constraints>
                             <constraint firstItem="abd-jd-9tI" firstAttribute="top" secondItem="xw9-Ro-Fai" secondAttribute="bottom" id="2UE-0c-j5w"/>
                             <constraint firstItem="BJx-hX-58b" firstAttribute="top" secondItem="SQe-Tw-wQG" secondAttribute="top" constant="125" id="Ctw-fE-ucI"/>
-                            <constraint firstItem="jyC-G0-Vbc" firstAttribute="leading" secondItem="JYP-Gu-HBL" secondAttribute="leading" id="Jnz-cD-A1p"/>
                             <constraint firstItem="xw9-Ro-Fai" firstAttribute="leading" secondItem="JYP-Gu-HBL" secondAttribute="leading" id="L7s-F4-sIf"/>
-                            <constraint firstItem="xw9-Ro-Fai" firstAttribute="top" secondItem="jyC-G0-Vbc" secondAttribute="bottom" id="MW5-hy-CGk"/>
                             <constraint firstItem="abd-jd-9tI" firstAttribute="leading" secondItem="JYP-Gu-HBL" secondAttribute="leading" id="SBf-Qz-WXs"/>
-                            <constraint firstItem="jyC-G0-Vbc" firstAttribute="top" secondItem="JYP-Gu-HBL" secondAttribute="top" id="XOx-7Z-PXh"/>
                             <constraint firstItem="abd-jd-9tI" firstAttribute="trailing" secondItem="JYP-Gu-HBL" secondAttribute="trailing" id="Z07-2o-YAz"/>
                             <constraint firstItem="xw9-Ro-Fai" firstAttribute="trailing" secondItem="JYP-Gu-HBL" secondAttribute="trailing" id="imf-Fu-CBo"/>
-                            <constraint firstItem="jyC-G0-Vbc" firstAttribute="trailing" secondItem="JYP-Gu-HBL" secondAttribute="trailing" id="jrd-cT-OYe"/>
+                            <constraint firstItem="JYP-Gu-HBL" firstAttribute="top" secondItem="xw9-Ro-Fai" secondAttribute="top" id="sPq-5G-3wa"/>
                             <constraint firstItem="BJx-hX-58b" firstAttribute="centerX" secondItem="xw9-Ro-Fai" secondAttribute="centerX" id="sdn-2O-8GI"/>
                             <constraint firstItem="abd-jd-9tI" firstAttribute="bottom" secondItem="SQe-Tw-wQG" secondAttribute="bottom" constant="20" id="zuH-3C-T3Q"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="JYP-Gu-HBL"/>
                     </view>
+                    <navigationItem key="navigationItem" title="Search for Location" id="FaM-WV-S6I">
+                        <barButtonItem key="rightBarButtonItem" systemItem="cancel" id="1Lg-Le-97T">
+                            <connections>
+                                <action selector="cancel:" destination="siu-I6-IEp" id="JLa-m4-1ei"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="_activityIndicator" destination="BJx-hX-58b" id="Qaa-v5-g28"/>
                         <outlet property="_searchBar" destination="xw9-Ro-Fai" id="uxK-r6-i4V"/>
@@ -5468,6 +5460,22 @@ This Privacy Policy may be updated from time to time for any reason. We will not
                 <placeholder placeholderIdentifier="IBFirstResponder" id="QOY-V7-23X" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-3703" y="-881"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="YTa-de-xid">
+            <objects>
+                <navigationController id="TCa-h6-J4b" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="gM1-Uk-3Nn">
+                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="siu-I6-IEp" kind="relationship" relationship="rootViewController" id="r7K-5q-X63"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="4ep-D2-P5g" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="139" y="-1090"/>
         </scene>
     </scenes>
     <resources>

--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -107,7 +107,7 @@
                                             <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>
                                         <connections>
-                                            <segue destination="XIv-Uv-W3O" kind="modal" id="CvQ-Su-F4k"/>
+                                            <segue destination="tSG-1g-AqH" kind="modal" id="D2E-xQ-BeP"/>
                                         </connections>
                                     </button>
                                     <view alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g4c-aL-FjW">
@@ -2698,7 +2698,23 @@ http://glyphish.com
             </objects>
             <point key="canvasLocation" x="-2198" y="-1090"/>
         </scene>
-        <!--Help View Controller-->
+        <!--Navigation Controller-->
+        <scene sceneID="1p7-Qc-3Vu">
+            <objects>
+                <navigationController id="tSG-1g-AqH" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="RlG-YW-YZ2">
+                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="XIv-Uv-W3O" kind="relationship" relationship="rootViewController" id="uwY-mY-BQN"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="P2T-Yi-Ton" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-2190" y="-1788"/>
+        </scene>
+        <!--Help-->
         <scene sceneID="ViH-as-IQq">
             <objects>
                 <viewController id="XIv-Uv-W3O" customClass="HelpViewController" sceneMemberID="viewController">
@@ -3474,39 +3490,30 @@ This Privacy Policy may be updated from time to time for any reason. We will not
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                 <dataDetectorType key="dataDetectorTypes" link="YES"/>
                             </textView>
-                            <navigationBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="at5-53-Fcu">
-                                <rect key="frame" x="0.0" y="20" width="320" height="44"/>
-                                <color key="barTintColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
-                                <items>
-                                    <navigationItem title="Help" id="hKF-nO-JpA">
-                                        <barButtonItem key="rightBarButtonItem" systemItem="cancel" id="TBM-Qb-u66">
-                                            <connections>
-                                                <action selector="cancel:" destination="XIv-Uv-W3O" id="EjB-xg-Xvy"/>
-                                            </connections>
-                                        </barButtonItem>
-                                    </navigationItem>
-                                </items>
-                            </navigationBar>
                         </subviews>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="rQo-Nf-qGw" firstAttribute="leading" secondItem="ZCh-OS-VVE" secondAttribute="leading" id="0Qi-Fv-vmn"/>
                             <constraint firstItem="rQo-Nf-qGw" firstAttribute="bottom" secondItem="hRy-vu-CNs" secondAttribute="bottom" id="CDf-dd-22f"/>
-                            <constraint firstItem="at5-53-Fcu" firstAttribute="trailing" secondItem="ZCh-OS-VVE" secondAttribute="trailing" id="f58-BZ-43W"/>
+                            <constraint firstItem="rQo-Nf-qGw" firstAttribute="top" secondItem="ZCh-OS-VVE" secondAttribute="top" id="U7f-dy-Pwh"/>
                             <constraint firstItem="rQo-Nf-qGw" firstAttribute="trailing" secondItem="ZCh-OS-VVE" secondAttribute="trailing" id="pfi-r8-m9z"/>
-                            <constraint firstItem="at5-53-Fcu" firstAttribute="leading" secondItem="ZCh-OS-VVE" secondAttribute="leading" id="seo-1c-jiV"/>
-                            <constraint firstItem="at5-53-Fcu" firstAttribute="top" secondItem="ZCh-OS-VVE" secondAttribute="top" id="vOY-44-38b"/>
-                            <constraint firstItem="rQo-Nf-qGw" firstAttribute="top" secondItem="at5-53-Fcu" secondAttribute="bottom" id="wWv-hj-8f8"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="ZCh-OS-VVE"/>
                     </view>
+                    <navigationItem key="navigationItem" title="Help" id="LPf-te-M9b">
+                        <barButtonItem key="rightBarButtonItem" systemItem="cancel" id="TBM-Qb-u66">
+                            <connections>
+                                <action selector="cancel:" destination="XIv-Uv-W3O" id="EjB-xg-Xvy"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="_textView" destination="rQo-Nf-qGw" id="wGj-kw-lAv"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="crr-EC-dTw" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-1418" y="-1090"/>
+            <point key="canvasLocation" x="-1365" y="-1789"/>
         </scene>
         <!--Bing Metadata View Controller-->
         <scene sceneID="I12-cf-9pY">
@@ -5509,7 +5516,7 @@ This Privacy Policy may be updated from time to time for any reason. We will not
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="g2g-Jn-Tdv"/>
-        <segue reference="ZKT-be-rhK"/>
+        <segue reference="OEI-9h-7td"/>
         <segue reference="KuK-gp-RBs"/>
         <segue reference="FTo-kL-oAC"/>
         <segue reference="mrH-5v-JIV"/>

--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -2121,14 +2121,14 @@ Clear the Mapnik or Overlay tile caches  to download the latest tiles that refle
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Clear GPS Overlay Tiles" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="klC-Oh-Oyd">
-                                                    <rect key="frame" x="15" y="3" width="187.5" height="20.5"/>
+                                                    <rect key="frame" x="16" y="3" width="187.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </label>
                                                 <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Subtitle" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UT3-uR-YpN">
-                                                    <rect key="frame" x="15" y="23.5" width="53" height="18"/>
+                                                    <rect key="frame" x="16" y="23.5" width="53" height="18"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                     <color key="textColor" red="0.50196078430000002" green="0.50196078430000002" blue="0.50196078430000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -3817,6 +3817,11 @@ This Privacy Policy may be updated from time to time for any reason. We will not
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="color" keyPath="view.backgroundColor">
+                            <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
                     <connections>
                         <segue destination="2" kind="relationship" relationship="rootViewController" id="aLN-Kg-iHf"/>
                     </connections>

--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -238,10 +238,10 @@
                         <outlet property="locationButton" destination="e3U-Im-GKP" id="LSh-pS-Mw5"/>
                         <outlet property="mapView" destination="fss-Ag-fKJ" id="dCu-lv-5cU"/>
                         <segue destination="f5t-25-IXF" kind="modal" identifier="poiSegue" id="OEI-9h-7td"/>
-                        <segue destination="S30-cU-QcE" kind="modal" identifier="NotesSegue" id="gMc-ga-KGQ"/>
                         <segue destination="Fhw-zr-ueA" kind="modal" identifier="CalculateHeightSegue" id="Tzh-5J-H7G"/>
                         <segue destination="DCR-m3-Qgc" kind="modal" identifier="BingMetadataSegue" id="OSh-Rq-XOM"/>
                         <segue destination="TCa-h6-J4b" kind="modal" identifier="searchSegue" id="RuH-7x-qpi"/>
+                        <segue destination="wrG-56-yuW" kind="modal" identifier="NotesSegue" id="ROf-ZO-hu1"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="10" sceneMemberID="firstResponder"/>
@@ -1370,7 +1370,23 @@
             </objects>
             <point key="canvasLocation" x="293" y="1819"/>
         </scene>
-        <!--Notes Table View Controller-->
+        <!--Navigation Controller-->
+        <scene sceneID="IuR-Zy-phT">
+            <objects>
+                <navigationController id="wrG-56-yuW" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="n2c-NG-Rrn">
+                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="S30-cU-QcE" kind="relationship" relationship="rootViewController" id="jzd-kX-GEf"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="LaK-ox-R0W" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-4543" y="639"/>
+        </scene>
+        <!--Note-->
         <scene sceneID="12g-at-ojg">
             <objects>
                 <viewController id="S30-cU-QcE" customClass="NotesTableViewController" sceneMemberID="viewController">
@@ -1378,20 +1394,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C3v-kD-Re9">
-                                <rect key="frame" x="0.0" y="20" width="320" height="44"/>
-                                <items>
-                                    <navigationItem title="Note" id="qIZ-iS-gwF">
-                                        <barButtonItem key="rightBarButtonItem" style="done" systemItem="cancel" id="uMQ-Rj-wEm">
-                                            <connections>
-                                                <action selector="done:" destination="S30-cU-QcE" id="85d-qs-S5A"/>
-                                            </connections>
-                                        </barButtonItem>
-                                    </navigationItem>
-                                </items>
-                            </navigationBar>
                             <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" sectionHeaderHeight="10" sectionFooterHeight="10" translatesAutoresizingMaskIntoConstraints="NO" id="DRB-XW-UOn">
-                                <rect key="frame" x="0.0" y="60" width="320" height="420"/>
+                                <rect key="frame" x="0.0" y="64" width="320" height="416"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <prototypes>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="noteCommentCell" rowHeight="102" id="6Un-rp-X2n" customClass="NotesCommentCell">
@@ -1545,14 +1549,18 @@
                         <constraints>
                             <constraint firstItem="DRB-XW-UOn" firstAttribute="bottom" secondItem="gog-wr-wAd" secondAttribute="bottom" id="4Vi-cw-zUc"/>
                             <constraint firstItem="DRB-XW-UOn" firstAttribute="leading" secondItem="gog-wr-wAd" secondAttribute="leading" id="GMA-z8-Au9"/>
-                            <constraint firstItem="C3v-kD-Re9" firstAttribute="top" secondItem="gog-wr-wAd" secondAttribute="top" id="HvL-Bn-Rbg"/>
-                            <constraint firstItem="DRB-XW-UOn" firstAttribute="top" secondItem="gog-wr-wAd" secondAttribute="top" constant="40" id="J6W-fa-HO8"/>
-                            <constraint firstItem="DRB-XW-UOn" firstAttribute="trailing" secondItem="C3v-kD-Re9" secondAttribute="trailing" id="UUc-fa-MNM"/>
+                            <constraint firstItem="DRB-XW-UOn" firstAttribute="top" secondItem="gog-wr-wAd" secondAttribute="top" id="J6W-fa-HO8"/>
                             <constraint firstItem="gog-wr-wAd" firstAttribute="trailing" secondItem="DRB-XW-UOn" secondAttribute="trailing" id="aLK-Zt-rkq"/>
-                            <constraint firstItem="DRB-XW-UOn" firstAttribute="leading" secondItem="C3v-kD-Re9" secondAttribute="leading" id="qR6-by-uBI"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="gog-wr-wAd"/>
                     </view>
+                    <navigationItem key="navigationItem" title="Note" id="MBY-TK-Wuy">
+                        <barButtonItem key="rightBarButtonItem" style="done" systemItem="cancel" id="uMQ-Rj-wEm">
+                            <connections>
+                                <action selector="done:" destination="S30-cU-QcE" id="85d-qs-S5A"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="tableView" destination="DRB-XW-UOn" id="mVg-pg-tr4"/>
                     </connections>


### PR DESCRIPTION
This branch makes sure to use a proper `UINavigationController` instance when presenting the view controllers for
- "Search for Location" and
- "Note"

Furthermore, it uses a _User Defined Runtime Attribute_ to set the `backgroundColor` of the map navigation controller's view to white in order to avoid a dark top-right corner when pushing the settings.