### PR TITLE
Fix: Dismiss the keyboard along with the "Search for Location" view controller

### DIFF
--- a/src/iOS/NominatumViewController.m
+++ b/src/iOS/NominatumViewController.m
@@ -35,6 +35,8 @@
 
 -(void)viewWillDisappear:(BOOL)animated
 {
+    [self.view endEditing:YES];
+    
 	[super viewWillDisappear:animated];
 	[[NSUserDefaults standardUserDefaults] setObject:_historyArray forKey:@"searchHistory"];
 }


### PR DESCRIPTION
This makes sure that the keyboard is no longer visible when back on the map.