### PR TITLE
Fix: Use localized presets for placeholder

### DIFF
--- a/src/Shared/CommonTagList.m
+++ b/src/Shared/CommonTagList.m
@@ -229,11 +229,11 @@ static NSString * PrettyTag( NSString * tag )
 					if ( i >= presets.count )
 						break;
 					CommonTagValue * p = presets[i];
-					if ( p.tagValue.length >= 20 )
+					if ( p.name.length >= 20 )
 						continue;
 					if ( s.length )
 						[s appendString:@", "];
-					[s appendString:p.tagValue];
+					[s appendString:p.name];
 				}
 				[s appendString:@"..."];
 				placeholder = s;

--- a/src/iOS/Go Map!!-Bridging-Header.h
+++ b/src/iOS/Go Map!!-Bridging-Header.h
@@ -3,3 +3,4 @@
 //
 
 #import "OsmObjects.h"
+#import "CommonTagList.h"

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -506,6 +506,7 @@
 		647F46CE2253EA4C00CEC482 /* MeasureDirectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647F46CD2253EA4C00CEC482 /* MeasureDirectionViewModel.swift */; };
 		647F46D12253F08200CEC482 /* HeadingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647F46D02253F08200CEC482 /* HeadingProvider.swift */; };
 		64C072FA226227D500598078 /* CommonTagKeyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C072F9226227D500598078 /* CommonTagKeyTestCase.swift */; };
+		64C072FE22622B9C00598078 /* Require.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C072FD22622B9C00598078 /* Require.swift */; };
 		64D74BF32253DF49004FFD20 /* DirectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D74BF12253DF49004FFD20 /* DirectionViewController.swift */; };
 		64D74BF42253DF49004FFD20 /* DirectionViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 64D74BF22253DF49004FFD20 /* DirectionViewController.xib */; };
 		64348D01225E8D3F00ADE7FB /* OsmNode+Direction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64348D00225E8D3F00ADE7FB /* OsmNode+Direction.swift */; };
@@ -1124,6 +1125,7 @@
 		647F46CD2253EA4C00CEC482 /* MeasureDirectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureDirectionViewModel.swift; sourceTree = "<group>"; };
 		647F46D02253F08200CEC482 /* HeadingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadingProvider.swift; sourceTree = "<group>"; };
 		64C072F9226227D500598078 /* CommonTagKeyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonTagKeyTestCase.swift; sourceTree = "<group>"; };
+		64C072FD22622B9C00598078 /* Require.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Require.swift; sourceTree = "<group>"; };
 		64D74BF12253DF49004FFD20 /* DirectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionViewController.swift; sourceTree = "<group>"; };
 		64D74BF22253DF49004FFD20 /* DirectionViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DirectionViewController.xib; sourceTree = "<group>"; };
 		64348D00225E8D3F00ADE7FB /* OsmNode+Direction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OsmNode+Direction.swift"; sourceTree = "<group>"; };
@@ -1874,6 +1876,7 @@
 				64348CF6225E867800ADE7FB /* Mocks */,
 				64348D02225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift */,
 				64348CEC225E7CD900ADE7FB /* GoMapTests.swift */,
+				64C072FC22622B9C00598078 /* Vendor */,
 				64348CEE225E7CD900ADE7FB /* Info.plist */,
 			);
 			path = GoMapTests;
@@ -1907,6 +1910,14 @@
 			);
 			name = Observable;
 			path = ../Shared/Observable;
+			sourceTree = "<group>";
+		};
+		64C072FC22622B9C00598078 /* Vendor */ = {
+			isa = PBXGroup;
+			children = (
+				64C072FD22622B9C00598078 /* Require.swift */,
+			);
+			path = Vendor;
 			sourceTree = "<group>";
 		};
 		64D74BF02253DF39004FFD20 /* Direction */ = {
@@ -2550,6 +2561,7 @@
 				64348CFC225E867800ADE7FB /* MeasureDirectionViewModelDelegateMock.swift in Sources */,
 				64348CED225E7CD900ADE7FB /* GoMapTests.swift in Sources */,
 				64348CFB225E867800ADE7FB /* HeadingProviderMock.swift in Sources */,
+				64C072FE22622B9C00598078 /* Require.swift in Sources */,
 				64348CFD225E867800ADE7FB /* CLHeadingMock.swift in Sources */,
 				64348D03225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift in Sources */,
 			);

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -505,6 +505,7 @@
 		6442666922540EDF00C0D545 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6442666622540EDF00C0D545 /* Observable.swift */; };
 		647F46CE2253EA4C00CEC482 /* MeasureDirectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647F46CD2253EA4C00CEC482 /* MeasureDirectionViewModel.swift */; };
 		647F46D12253F08200CEC482 /* HeadingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647F46D02253F08200CEC482 /* HeadingProvider.swift */; };
+		64C072FA226227D500598078 /* CommonTagKeyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C072F9226227D500598078 /* CommonTagKeyTestCase.swift */; };
 		64D74BF32253DF49004FFD20 /* DirectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D74BF12253DF49004FFD20 /* DirectionViewController.swift */; };
 		64D74BF42253DF49004FFD20 /* DirectionViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 64D74BF22253DF49004FFD20 /* DirectionViewController.xib */; };
 		64348D01225E8D3F00ADE7FB /* OsmNode+Direction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64348D00225E8D3F00ADE7FB /* OsmNode+Direction.swift */; };
@@ -1122,6 +1123,7 @@
 		6442666622540EDF00C0D545 /* Observable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		647F46CD2253EA4C00CEC482 /* MeasureDirectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureDirectionViewModel.swift; sourceTree = "<group>"; };
 		647F46D02253F08200CEC482 /* HeadingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadingProvider.swift; sourceTree = "<group>"; };
+		64C072F9226227D500598078 /* CommonTagKeyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonTagKeyTestCase.swift; sourceTree = "<group>"; };
 		64D74BF12253DF49004FFD20 /* DirectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionViewController.swift; sourceTree = "<group>"; };
 		64D74BF22253DF49004FFD20 /* DirectionViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DirectionViewController.xib; sourceTree = "<group>"; };
 		64348D00225E8D3F00ADE7FB /* OsmNode+Direction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OsmNode+Direction.swift"; sourceTree = "<group>"; };
@@ -1867,6 +1869,7 @@
 		64348CEB225E7CD900ADE7FB /* GoMapTests */ = {
 			isa = PBXGroup;
 			children = (
+				64C072F9226227D500598078 /* CommonTagKeyTestCase.swift */,
 				64348CFA225E867800ADE7FB /* MeasureDirectionViewModelTestCase.swift */,
 				64348CF6225E867800ADE7FB /* Mocks */,
 				64348D02225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift */,
@@ -2543,6 +2546,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				64348CFE225E867800ADE7FB /* MeasureDirectionViewModelTestCase.swift in Sources */,
+				64C072FA226227D500598078 /* CommonTagKeyTestCase.swift in Sources */,
 				64348CFC225E867800ADE7FB /* MeasureDirectionViewModelDelegateMock.swift in Sources */,
 				64348CED225E7CD900ADE7FB /* GoMapTests.swift in Sources */,
 				64348CFB225E867800ADE7FB /* HeadingProviderMock.swift in Sources */,

--- a/src/iOS/GoMapTests/CommonTagKeyTestCase.swift
+++ b/src/iOS/GoMapTests/CommonTagKeyTestCase.swift
@@ -8,26 +8,8 @@
 
 import XCTest
 
+@testable import Go_Map__
+
 class CommonTagKeyTestCase: XCTestCase {
-
-    override func setUp() {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
 
 }

--- a/src/iOS/GoMapTests/CommonTagKeyTestCase.swift
+++ b/src/iOS/GoMapTests/CommonTagKeyTestCase.swift
@@ -1,0 +1,33 @@
+//
+//  CommonTagKeyTestCase.swift
+//  GoMapTests
+//
+//  Created by Wolfgang Timme on 4/13/19.
+//  Copyright © 2019 Bryce. All rights reserved.
+//
+
+import XCTest
+
+class CommonTagKeyTestCase: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/src/iOS/GoMapTests/CommonTagKeyTestCase.swift
+++ b/src/iOS/GoMapTests/CommonTagKeyTestCase.swift
@@ -11,5 +11,23 @@ import XCTest
 @testable import Go_Map__
 
 class CommonTagKeyTestCase: XCTestCase {
+    
+    func testInitWithPresetsShouldUseTheirNamesForPlaceholder() {
+        let firstPresetName = "Ja"
+        let firstPreset = CommonTagValue(name: firstPresetName, details: "", tagValue: "yes")
+        
+        let secondPresentName = "Nein"
+        let secondPreset = CommonTagValue(name: secondPresentName, details: "", tagValue: "no")
+        
+        let tagKey = CommonTagKey(name: "Rückenlehne",
+                                  tagKey: "backreset",
+                                  defaultValue: nil,
+                                  placeholder: nil,
+                                  keyboard: .default,
+                                  capitalize: .none,
+                                  presets: [firstPreset, secondPreset])
+        
+        XCTAssertEqual(tagKey.require().placeholder, "\(firstPresetName), \(secondPresentName)...")
+    }
 
 }

--- a/src/iOS/GoMapTests/CommonTagKeyTestCase.swift
+++ b/src/iOS/GoMapTests/CommonTagKeyTestCase.swift
@@ -12,6 +12,23 @@ import XCTest
 
 class CommonTagKeyTestCase: XCTestCase {
     
+    func testInitWithPresetsShouldPreferThePlaceholderParameterIfProvided() {
+        let placeholder = "Lorem ipsum"
+        
+        let firstPreset = CommonTagValue(name: "Ja", details: "", tagValue: "yes")
+        let secondPreset = CommonTagValue(name: "Nein", details: "", tagValue: "no")
+        
+        let tagKey = CommonTagKey(name: "Rückenlehne",
+                                  tagKey: "backreset",
+                                  defaultValue: nil,
+                                  placeholder: placeholder,
+                                  keyboard: .default,
+                                  capitalize: .none,
+                                  presets: [firstPreset, secondPreset])
+        
+        XCTAssertEqual(tagKey.require().placeholder, placeholder)
+    }
+    
     func testInitWithPresetsShouldUseTheirNamesForPlaceholder() {
         let firstPresetName = "Ja"
         let firstPreset = CommonTagValue(name: firstPresetName, details: "", tagValue: "yes")

--- a/src/iOS/GoMapTests/Vendor/Require.swift
+++ b/src/iOS/GoMapTests/Vendor/Require.swift
@@ -1,0 +1,46 @@
+/**
+ *  Require
+ *  Copyright (c) John Sundell 2017
+ *  Licensed under the MIT license. See LICENSE file.
+ */
+
+import Foundation
+
+public extension Optional {
+    /**
+     *  Require this optional to contain a non-nil value
+     *
+     *  This method will either return the value that this optional contains, or trigger
+     *  a `preconditionFailure` with an error message containing debug information.
+     *
+     *  - parameter hint: Optionally pass a hint that will get included in any error
+     *                    message generated in case nil was found.
+     *
+     *  - return: The value this optional contains.
+     */
+    func require(hint hintExpression: @autoclosure () -> String? = nil,
+                 file: StaticString = #file,
+                 line: UInt = #line) -> Wrapped {
+        guard let unwrapped = self else {
+            var message = "Required value was nil in \(file), at line \(line)"
+
+            if let hint = hintExpression() {
+                message.append(". Debugging hint: \(hint)")
+            }
+
+            #if !os(Linux)
+            let exception = NSException(
+                name: .invalidArgumentException,
+                reason: message,
+                userInfo: nil
+            )
+
+            exception.raise()
+            #endif
+
+            preconditionFailure(message)
+        }
+
+        return unwrapped
+    }
+}


### PR DESCRIPTION
This fixes #139.

## Preview

![Screenshot of "Common Tags" that shows localized placeholders](https://user-images.githubusercontent.com/1681085/56081356-ed3ec880-5dfb-11e9-970f-5404218fd532.png)
