### PR TITLE
Fix: "unsupported url" error message during upload

### DIFF
--- a/src/Shared/OsmMapData.h
+++ b/src/Shared/OsmMapData.h
@@ -1,5 +1,5 @@
 //
-//  XmlParserDelegate.h
+//  OsmMapData.h
 //  OpenStreetMap
 //
 //  Created by Bryce Cogswell on 9/1/12.

--- a/src/Shared/OsmMapData.h
+++ b/src/Shared/OsmMapData.h
@@ -64,6 +64,14 @@ typedef OsmNode   * (^EditActionReturnNode)(void);
 	NSTimer				*	_periodicSaveTimer;
 }
 
+/**
+ Initializes the object.
+
+ @param userDefaults The `UserDefaults` instance to use.
+ @return An initialized instance of this object.
+ */
+- (instancetype)initWithUserDefaults:(NSUserDefaults *)userDefaults;
+
 @property (copy,nonatomic)	NSString *	credentialsUserName;
 @property (copy,nonatomic)	NSString *	credentialsPassword;
 

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -1,5 +1,5 @@
 //
-//  XmlParserDelegate.m
+//  OsmMapData.m
 //  OpenStreetMap
 //
 //  Created by Bryce Cogswell on 9/1/12.

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -123,7 +123,7 @@ static EditorMapLayer * g_EditorMapLayerForArchive = nil;
 	if ( [hostname hasSuffix:@"/"] ) {
 		// great
 	} else {
-		hostname = [hostname stringByAppendingString:@"//"];
+		hostname = [hostname stringByAppendingString:@"/"];
 	}
 
 	if ( OSM_API_URL.length ) {

--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -1163,7 +1163,7 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Login" id="O6E-f1-A1k">
                         <barButtonItem key="backBarButtonItem" title="Back" id="kt1-K7-kcu"/>
-                        <barButtonItem key="rightBarButtonItem" title="Verify" style="done" id="ctb-pg-pM9">
+                        <barButtonItem key="rightBarButtonItem" title="Save" style="done" id="ctb-pg-pM9">
                             <connections>
                                 <action selector="verifyAccount:" destination="kl3-Fg-1QU" id="qEc-ab-jnj"/>
                             </connections>

--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -1172,8 +1172,8 @@
                     <connections>
                         <outlet property="_activityIndicator" destination="jcT-tR-WDO" id="J8A-AQ-LZf"/>
                         <outlet property="_password" destination="e7I-rE-dAW" id="Ugu-EO-x5C"/>
+                        <outlet property="_saveButton" destination="ctb-pg-pM9" id="qk6-V6-1jq"/>
                         <outlet property="_username" destination="YQ4-05-lQz" id="ge6-8t-VeT"/>
-                        <outlet property="_verifyButton" destination="ctb-pg-pM9" id="5cm-I2-11p"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="CzF-UG-rbA" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -1062,7 +1062,7 @@
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="240" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="username" translatesAutoresizingMaskIntoConstraints="NO" id="YQ4-05-lQz">
                                                     <rect key="frame" x="142" y="11.5" width="159" height="21"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <textInputTraits key="textInputTraits" returnKeyType="done"/>
+                                                    <textInputTraits key="textInputTraits" spellCheckingType="no" returnKeyType="done"/>
                                                     <connections>
                                                         <action selector="textFieldDidChange:" destination="kl3-Fg-1QU" eventType="editingChanged" id="5aR-9a-sW0"/>
                                                         <action selector="textFieldReturn:" destination="kl3-Fg-1QU" eventType="editingDidEndOnExit" id="HIT-FM-Ke9"/>

--- a/src/iOS/Extensions/LoginViewController.swift
+++ b/src/iOS/Extensions/LoginViewController.swift
@@ -1,0 +1,22 @@
+//
+//  LoginViewController.swift
+//  Go Map!!
+//
+//  Created by Wolfgang Timme on 4/15/19.
+//  Copyright © 2019 Bryce. All rights reserved.
+//
+
+import UIKit
+
+extension LoginViewController {
+    @objc func saveVerifiedCredentials(username: String, password: String) {
+        KeyChain.setString(username, forIdentifier: "username")
+        KeyChain.setString(password, forIdentifier: "password")
+        
+        // Update the app delegate as well.
+        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+            appDelegate.userName = username
+            appDelegate.userPassword = password
+        }
+    }
+}

--- a/src/iOS/Go Map!!-Bridging-Header.h
+++ b/src/iOS/Go Map!!-Bridging-Header.h
@@ -7,3 +7,4 @@
 #import "LoginViewController.h"
 #import "KeyChain.h"
 #import "AppDelegate.h"
+#import "OsmMapData.h"

--- a/src/iOS/Go Map!!-Bridging-Header.h
+++ b/src/iOS/Go Map!!-Bridging-Header.h
@@ -4,3 +4,6 @@
 
 #import "OsmObjects.h"
 #import "CommonTagList.h"
+#import "LoginViewController.h"
+#import "KeyChain.h"
+#import "AppDelegate.h"

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -511,6 +511,7 @@
 		64348D01225E8D3F00ADE7FB /* OsmNode+Direction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64348D00225E8D3F00ADE7FB /* OsmNode+Direction.swift */; };
 		64348D03225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64348D02225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift */; };
 		64E21EB322651620004605D7 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E21EB222651620004605D7 /* LoginViewController.swift */; };
+		64E21EB522651C06004605D7 /* OSMMapDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E21EB422651C06004605D7 /* OSMMapDataTestCase.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1130,6 +1131,7 @@
 		64348D00225E8D3F00ADE7FB /* OsmNode+Direction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OsmNode+Direction.swift"; sourceTree = "<group>"; };
 		64348D02225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OsmNode_DirectionTestCase.swift; sourceTree = "<group>"; };
 		64E21EB222651620004605D7 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
+		64E21EB422651C06004605D7 /* OSMMapDataTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSMMapDataTestCase.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1878,6 +1880,7 @@
 				64348CEC225E7CD900ADE7FB /* GoMapTests.swift */,
 				64C072FC22622B9C00598078 /* Vendor */,
 				64348CEE225E7CD900ADE7FB /* Info.plist */,
+				64E21EB422651C06004605D7 /* OSMMapDataTestCase.swift */,
 			);
 			path = GoMapTests;
 			sourceTree = "<group>";
@@ -2572,6 +2575,7 @@
 				64C072FE22622B9C00598078 /* Require.swift in Sources */,
 				64348CFD225E867800ADE7FB /* CLHeadingMock.swift in Sources */,
 				64348D03225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift in Sources */,
+				64E21EB522651C06004605D7 /* OSMMapDataTestCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -510,6 +510,7 @@
 		64D74BF42253DF49004FFD20 /* DirectionViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 64D74BF22253DF49004FFD20 /* DirectionViewController.xib */; };
 		64348D01225E8D3F00ADE7FB /* OsmNode+Direction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64348D00225E8D3F00ADE7FB /* OsmNode+Direction.swift */; };
 		64348D03225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64348D02225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift */; };
+		64E21EB322651620004605D7 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E21EB222651620004605D7 /* LoginViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1128,6 +1129,7 @@
 		64D74BF22253DF49004FFD20 /* DirectionViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DirectionViewController.xib; sourceTree = "<group>"; };
 		64348D00225E8D3F00ADE7FB /* OsmNode+Direction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OsmNode+Direction.swift"; sourceTree = "<group>"; };
 		64348D02225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OsmNode_DirectionTestCase.swift; sourceTree = "<group>"; };
+		64E21EB222651620004605D7 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1362,6 +1364,7 @@
 		02ACBA3916713CCB00BB4414 /* Go Map! */ = {
 			isa = PBXGroup;
 			children = (
+				64E21EB122651615004605D7 /* Extensions */,
 				64D74BF02253DF39004FFD20 /* Direction */,
 				02C3C73519A5D679003B6783 /* AerialEditViewController.h */,
 				02C3C73619A5D679003B6783 /* AerialEditViewController.m */,
@@ -1929,6 +1932,14 @@
 			path = Direction;
 			sourceTree = "<group>";
 		};
+		64E21EB122651615004605D7 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				64E21EB222651620004605D7 /* LoginViewController.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -2474,6 +2485,7 @@
 				02E626701997168800565D62 /* KeyChain.m in Sources */,
 				02ACBBCA16713F2B00BB4414 /* MapView.m in Sources */,
 				02BF745120793EE20028ED6A /* TurnRestrictHwyView.m in Sources */,
+				64E21EB322651620004605D7 /* LoginViewController.swift in Sources */,
 				02ACBBCB16713F2B00BB4414 /* MercatorTileLayer.m in Sources */,
 				02ACBBCC16713F2B00BB4414 /* OsmMapData.m in Sources */,
 				027EDC71206F3EED00D349D6 /* DDXMLElementAdditions.m in Sources */,

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -512,6 +512,7 @@
 		64348D03225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64348D02225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift */; };
 		64E21EB322651620004605D7 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E21EB222651620004605D7 /* LoginViewController.swift */; };
 		64E21EB522651C06004605D7 /* OSMMapDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E21EB422651C06004605D7 /* OSMMapDataTestCase.swift */; };
+		64E21EB822651F2D004605D7 /* XCTestCase+UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E21EB722651F2D004605D7 /* XCTestCase+UserDefaults.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1132,6 +1133,7 @@
 		64348D02225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OsmNode_DirectionTestCase.swift; sourceTree = "<group>"; };
 		64E21EB222651620004605D7 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		64E21EB422651C06004605D7 /* OSMMapDataTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSMMapDataTestCase.swift; sourceTree = "<group>"; };
+		64E21EB722651F2D004605D7 /* XCTestCase+UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+UserDefaults.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1873,6 +1875,7 @@
 		64348CEB225E7CD900ADE7FB /* GoMapTests */ = {
 			isa = PBXGroup;
 			children = (
+				64E21EB622651F0D004605D7 /* Helpers */,
 				64C072F9226227D500598078 /* CommonTagKeyTestCase.swift */,
 				64348CFA225E867800ADE7FB /* MeasureDirectionViewModelTestCase.swift */,
 				64348CF6225E867800ADE7FB /* Mocks */,
@@ -1941,6 +1944,14 @@
 				64E21EB222651620004605D7 /* LoginViewController.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		64E21EB622651F0D004605D7 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				64E21EB722651F2D004605D7 /* XCTestCase+UserDefaults.swift */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2572,6 +2583,7 @@
 				64348CFC225E867800ADE7FB /* MeasureDirectionViewModelDelegateMock.swift in Sources */,
 				64348CED225E7CD900ADE7FB /* GoMapTests.swift in Sources */,
 				64348CFB225E867800ADE7FB /* HeadingProviderMock.swift in Sources */,
+				64E21EB822651F2D004605D7 /* XCTestCase+UserDefaults.swift in Sources */,
 				64C072FE22622B9C00598078 /* Require.swift in Sources */,
 				64348CFD225E867800ADE7FB /* CLHeadingMock.swift in Sources */,
 				64348D03225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift in Sources */,

--- a/src/iOS/Go Map!!.xcodeproj/xcshareddata/xcschemes/GoMapTests.xcscheme
+++ b/src/iOS/Go Map!!.xcodeproj/xcshareddata/xcschemes/GoMapTests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "64348CE9225E7CD900ADE7FB"
+               BuildableName = "GoMapTests.xctest"
+               BlueprintName = "GoMapTests"
+               ReferencedContainer = "container:Go Map!!.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/src/iOS/GoMapTests/Helpers/XCTestCase+UserDefaults.swift
+++ b/src/iOS/GoMapTests/Helpers/XCTestCase+UserDefaults.swift
@@ -1,0 +1,22 @@
+//
+//  XCTestCase+UserDefaults.swift
+//  GoMapTests
+//
+//  Created by Wolfgang Timme on 4/15/19.
+//  Copyright © 2019 Bryce. All rights reserved.
+//
+
+import XCTest
+
+extension XCTestCase {
+    
+    /// Creates `UserDefaults` that use the test case' name as the `suitename`.
+    ///
+    /// - Returns: A `UserDefaults` instance that is dedicated for this test case.
+    func createDedicatedUserDefaults() -> UserDefaults? {
+        let testCaseName = String(describing: self)
+        
+        return UserDefaults(suiteName: testCaseName)
+    }
+    
+}

--- a/src/iOS/GoMapTests/OSMMapDataTestCase.swift
+++ b/src/iOS/GoMapTests/OSMMapDataTestCase.swift
@@ -1,0 +1,39 @@
+//
+//  OSMMapDataTestCase.swift
+//  GoMapTests
+//
+//  Created by Wolfgang Timme on 4/15/19.
+//  Copyright © 2019 Bryce. All rights reserved.
+//
+
+import XCTest
+@testable import Go_Map__
+
+class OSMMapDataTestCase: XCTestCase {
+    
+    var mapData: OsmMapData!
+
+    override func setUp() {
+        mapData = OsmMapData()
+    }
+
+    override func tearDown() {
+        mapData = nil
+    }
+    
+    func testSetServerShouldAddThePathSeparatorSuffixIfItDoesNotExist() {
+        let hostname = "https://example.com"
+        mapData.setServer(hostname)
+        
+        let hostnameWithPathSeparatorSuffix = "\(hostname)/"
+        XCTAssertEqual(OSM_API_URL, hostnameWithPathSeparatorSuffix)
+    }
+    
+    func testSetServerShouldNotAddThePathSeparatorSuffixIfItAlreadyExists() {
+        let hostname = "https://example.com/"
+        mapData.setServer(hostname)
+        
+        XCTAssertEqual(OSM_API_URL, hostname)
+    }
+
+}

--- a/src/iOS/GoMapTests/OSMMapDataTestCase.swift
+++ b/src/iOS/GoMapTests/OSMMapDataTestCase.swift
@@ -12,13 +12,16 @@ import XCTest
 class OSMMapDataTestCase: XCTestCase {
     
     var mapData: OsmMapData!
+    var userDefaults: UserDefaults!
 
     override func setUp() {
-        mapData = OsmMapData()
+        userDefaults = createDedicatedUserDefaults()
+        mapData = OsmMapData(userDefaults: userDefaults)
     }
 
     override func tearDown() {
         mapData = nil
+        userDefaults = nil
     }
     
     func testSetServerShouldAddThePathSeparatorSuffixIfItDoesNotExist() {

--- a/src/iOS/LoginViewController.h
+++ b/src/iOS/LoginViewController.h
@@ -10,7 +10,7 @@
 
 @interface LoginViewController : UITableViewController
 {
-	IBOutlet UIBarButtonItem			*	_verifyButton;
+	IBOutlet UIBarButtonItem			*	_saveButton;
 	IBOutlet UITextField				*	_username;
 	IBOutlet UITextField				*	_password;
 	IBOutlet UIActivityIndicatorView	*	_activityIndicator;

--- a/src/iOS/LoginViewController.m
+++ b/src/iOS/LoginViewController.m
@@ -27,7 +27,7 @@
 
 - (IBAction)textFieldDidChange:(id)sender
 {
-	_verifyButton.enabled = _username.text.length && _password.text.length;
+	_saveButton.enabled = _username.text.length && _password.text.length;
 }
 
 - (IBAction)registerAccount:(id)sender
@@ -88,7 +88,7 @@
 	_username.text	= appDelegate.userName;
 	_password.text	= appDelegate.userPassword;
 
-	_verifyButton.enabled = _username.text.length && _password.text.length;
+	_saveButton.enabled = _username.text.length && _password.text.length;
 }
 
 #pragma mark - Table view delegate

--- a/src/iOS/LoginViewController.m
+++ b/src/iOS/LoginViewController.m
@@ -89,14 +89,6 @@
 	_verifyButton.enabled = _username.text.length && _password.text.length;
 }
 
-- (void)viewWillDisappear:(BOOL)animated
-{
-	[super viewWillDisappear:animated];
-    
-    [self saveVerifiedCredentialsWithUsername:[_username.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]
-                                     password:[_password.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];
-}
-
 #pragma mark - Table view delegate
 
 @end

--- a/src/iOS/LoginViewController.m
+++ b/src/iOS/LoginViewController.m
@@ -68,6 +68,8 @@
 			_password.text	= password;
 			[_username resignFirstResponder];
 			[_password resignFirstResponder];
+            
+            [self saveVerifiedCredentialsWithUsername:username password:password];
 
 			UIAlertController * alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Login successful",nil) message:nil preferredStyle:UIAlertControllerStyleAlert];
 			[alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK",nil) style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {

--- a/src/iOS/LoginViewController.m
+++ b/src/iOS/LoginViewController.m
@@ -40,10 +40,13 @@
 {
 	if ( _activityIndicator.isAnimating )
 		return;
+    
+    NSString *username = [_username.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    NSString *password = [_password.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 
 	AppDelegate * appDelegate = (id)[[UIApplication sharedApplication] delegate];
-	appDelegate.userName		= [_username.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-	appDelegate.userPassword	= [_password.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    appDelegate.userName		= username;
+    appDelegate.userPassword	= password;
 
 	_activityIndicator.color = UIColor.darkGrayColor;
 	[_activityIndicator startAnimating];
@@ -61,8 +64,8 @@
 			[self presentViewController:alert animated:YES completion:nil];
 		} else {
 			// verifying credentials may update the appDelegate values when we subsitute name for correct case:
-			_username.text	= appDelegate.userName;
-			_password.text	= appDelegate.userPassword;
+			_username.text	= username;
+			_password.text	= password;
 			[_username resignFirstResponder];
 			[_password resignFirstResponder];
 

--- a/src/iOS/LoginViewController.m
+++ b/src/iOS/LoginViewController.m
@@ -89,13 +89,9 @@
 - (void)viewWillDisappear:(BOOL)animated
 {
 	[super viewWillDisappear:animated];
-
-	AppDelegate * appDelegate = (id)[[UIApplication sharedApplication] delegate];
-	appDelegate.userName		= [_username.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-	appDelegate.userPassword	= [_password.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-
-	[KeyChain setString:appDelegate.userName forIdentifier:@"username"];
-	[KeyChain setString:appDelegate.userPassword forIdentifier:@"password"];
+    
+    [self saveVerifiedCredentialsWithUsername:[_username.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]
+                                     password:[_password.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];
 }
 
 #pragma mark - Table view delegate


### PR DESCRIPTION
This branch fixes #212.

There are a couple of changes:
1. Spell checking is now disabled for the "username" field
2. Only _verified_ (= correct) credentials are stored in the `KeyChain`
3. When changing the server and providing an URL without `/` as the suffix, the app only adds a single `/` to it - not two
4. Improve error handling for when the server does not respond with a numeric ID while attempting to create a changeset