### PR TITLE
Fix corner radius presentation of map icon layers

### DIFF
--- a/src/Shared/EditorMapLayer.m
+++ b/src/Shared/EditorMapLayer.m
@@ -1665,6 +1665,7 @@ const static CGFloat Z_ARROWS			= Z_BASE + 11 * ZSCALE;
         layer.contents        = (id)icon.CGImage;
         layer.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.75].CGColor;
         layer.cornerRadius    = 5;
+        layer.masksToBounds = YES;
         layer.zPosition        = Z_NODE;
         
         LayerProperties * props = [LayerProperties new];


### PR DESCRIPTION
By setting `masksToBounds`, the `cornerRadius` is applied properly. This makes sure they match the other (already rounded) icons.

## Visual comparison

Before:
![icons-without-rounded-corners](https://user-images.githubusercontent.com/1681085/56462437-7d5baf80-63b2-11e9-95fa-cca57ce07881.png)


After:
![icons-with-rounded-corners](https://user-images.githubusercontent.com/1681085/56462438-82b8fa00-63b2-11e9-91d0-ea4f61529e61.png)
