### PR TITLE
Fix initialization of OsmMapData

### DIFF
--- a/src/Shared/OsmMapData.h
+++ b/src/Shared/OsmMapData.h
@@ -70,7 +70,7 @@ typedef OsmNode   * (^EditActionReturnNode)(void);
  @param userDefaults The `UserDefaults` instance to use.
  @return An initialized instance of this object.
  */
-- (instancetype)initWithUserDefaults:(NSUserDefaults *)userDefaults;
+- (instancetype)initWithUserDefaults:(NSUserDefaults *)userDefaults NS_DESIGNATED_INITIALIZER;
 
 @property (copy,nonatomic)	NSString *	credentialsUserName;
 @property (copy,nonatomic)	NSString *	credentialsPassword;

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -102,6 +102,10 @@ static EditorMapLayer * g_EditorMapLayerForArchive = nil;
     return self;
 }
 
+- (instancetype)init {
+    return [self initWithUserDefaults:[NSUserDefaults standardUserDefaults]];
+}
+
 -(void)dealloc
 {
 	[_periodicSaveTimer invalidate];

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -2353,9 +2353,8 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 	NSKeyedUnarchiver * unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:data];
 	unarchiver.delegate = self;
 	self = [unarchiver decodeObjectForKey:@"OsmMapData"];
-	if ( self ) {
-		[self initCommon];
-
+	if ( self = [self init] ) {
+        
 		// rebuild spatial database
 		_spatial.rootQuad = [QuadBox new];
 		[self enumerateObjectsUsingBlock:^(OsmBaseObject *obj) {

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -1866,7 +1866,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 
 - (id)initWithCoder:(NSCoder *)coder
 {
-	self = [super init];
+	self = [self init];
 	if ( self ) {
 
 		@try {

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -798,7 +798,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 
 		} else {
 
-			OsmMapData * mapData = [[OsmMapData alloc] initWithUserDefaults:[NSUserDefaults standardUserDefaults]];
+			OsmMapData * mapData = [[OsmMapData alloc] init];
 			NSError * error = nil;
 			BOOL ok = [mapData parseXmlStream:stream error:&error];
 			if ( !ok ) {
@@ -2373,7 +2373,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 			NSMutableDictionary * newRelations	= [db querySqliteRelations];
 			NSAssert(newRelations,nil);
 
-			OsmMapData * newData = [[OsmMapData alloc] initWithUserDefaults:[NSUserDefaults standardUserDefaults]];
+			OsmMapData * newData = [[OsmMapData alloc] init];
 			newData->_nodes = newNodes;
 			newData->_ways = newWays;
 			newData->_relations = newRelations;


### PR DESCRIPTION
This branch makes sure that the designated initializer `initWithUserDefaults:` is called, and that the initializer chain is being kept. Otherwise, things that happen in the designated initializer will only _sometimes_ being invoked.

This fixes a crash for me when `OsmMapData` was created with `new` (= `alloc init`), which did not call the designated initializer (`initWithUserDefaults:`), which resulted in un-initialized instance variables.