### PR TITLE
Fix: OsmMapData is not decoded properly

### DIFF
--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -2354,7 +2354,6 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 	unarchiver.delegate = self;
 	self = [unarchiver decodeObjectForKey:@"OsmMapData"];
 	if ( self ) {
-		[self initCommon];
 
 		// rebuild spatial database
 		_spatial.rootQuad = [QuadBox new];

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -2353,8 +2353,9 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 	NSKeyedUnarchiver * unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:data];
 	unarchiver.delegate = self;
 	self = [unarchiver decodeObjectForKey:@"OsmMapData"];
-	if ( self = [self init] ) {
-        
+	if ( self ) {
+		[self initCommon];
+
 		// rebuild spatial database
 		_spatial.rootQuad = [QuadBox new];
 		[self enumerateObjectsUsingBlock:^(OsmBaseObject *obj) {


### PR DESCRIPTION
With 3de0260, I have introduced a change where the object that had just been decoded would be overwritten with `[self init]`. This results in the database entries not showing up on the map.

## Steps to reproduce
1. Open the app
2. Add a new node
3. Select a type (any will do) and hit "Save"
4. Hard-close the app
5. Open the app again

**Expected behaviour:** The new node persisted the restart and is visible on the map.
**Observed behaviour:** The new node is not visible on the map.

Sorry for introducing this, my bad! I'll try to remember to add unit tests the next time I introduce such changes.