### PR TITLE
OsmServerViewController is no-op if hostname string does not change.

### DIFF
--- a/src/iOS/OsmServerViewController.h
+++ b/src/iOS/OsmServerViewController.h
@@ -11,5 +11,6 @@
 @interface OsmServerViewController : UITableViewController
 
 @property (assign,nonatomic) IBOutlet UITextField	*	hostname;
+@property (retain, nonatomic) NSString	*	originalHostname;
 
 @end

--- a/src/iOS/OsmServerViewController.m
+++ b/src/iOS/OsmServerViewController.m
@@ -35,6 +35,7 @@
 	AppDelegate * appDelegate = [AppDelegate getAppDelegate];
 	OsmMapData * mapData = appDelegate.mapView.editorLayer.mapData;
 	self.hostname.text = [mapData getServer];
+	self.originalHostname = self.hostname.text;
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -43,7 +44,9 @@
 
 	AppDelegate * appDelegate = [AppDelegate getAppDelegate];
 	OsmMapData * mapData = appDelegate.mapView.editorLayer.mapData;
-	[mapData setServer:self.hostname.text];
+	if (![self.hostname.text isEqualToString:self.originalHostname]) {
+		[mapData setServer:self.hostname.text];
+    }
 }
 
 @end


### PR DESCRIPTION
@bryceco I said I would contribute if you open sourced this app :)

To reproduce:

1. use geolocation in app
2. open settings -> go to "Nearby Mappers"
3. Go back and select "Osm Server"
4. Go back to Nearby Mappers, list is empty!

This changes makes it so that navigating to "OSM Server" in settings and not changing anything will not invalidate the data state. 