### PR TITLE
Fix: Location search results are truncated

### DIFF
--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -3728,7 +3728,7 @@ This Privacy Policy may be updated from time to time for any reason. We will not
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="290" id="vRO-Aj-Sdr">
+                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="290" id="vRO-Aj-Sdr">
                                                     <rect key="frame" x="15" y="0.0" width="290" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>

--- a/src/iOS/NominatumViewController.m
+++ b/src/iOS/NominatumViewController.m
@@ -13,7 +13,8 @@
 #import "MapViewController.h"
 #import "NominatumViewController.h"
 
-
+@interface NominatumViewController() <UITableViewDelegate>
+@end
 
 @implementation NominatumViewController
 

--- a/src/iOS/NominatumViewController.m
+++ b/src/iOS/NominatumViewController.m
@@ -54,6 +54,14 @@
 	return _searchBar.text.length ? _resultsArray.count : _historyArray.count;
 }
 
+- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath {
+    return 44;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
+    return UITableViewAutomaticDimension;
+}
+
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     static NSString *CellIdentifier = @"Cell";


### PR DESCRIPTION
This branch allows for the cells in the location search to have unlimited number of lines (`0`). Longer text is no longer truncated:

![IMG_9831](https://user-images.githubusercontent.com/1681085/71739632-e48e9680-2e51-11ea-87a8-c07ab266220f.jpg)


Besides fixing #245, this improves the Accessibility of the app when using larger text.