### PR TITLE
Fix handling of notes when presented in navigation controller

### DIFF
--- a/src/iOS/MapViewController.m
+++ b/src/iOS/MapViewController.m
@@ -220,11 +220,20 @@
 -(void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender
 {
 	if ( [sender isKindOfClass:[OsmNote class]] ) {
-		NotesTableViewController * con = segue.destinationViewController;
-		if ( [con isKindOfClass:[NotesTableViewController class]] ) {
-			con.note = sender;
-			con.mapView = _mapView;
-		}
+        NotesTableViewController *con;
+        if ([segue.destinationViewController isKindOfClass:[NotesTableViewController class]]) {
+            /// The `NotesTableViewController` is presented directly.
+            con = segue.destinationViewController;
+        } else if ([segue.destinationViewController isKindOfClass:[UINavigationController class]]) {
+            UINavigationController *navigationController = segue.destinationViewController;
+            if ([navigationController.viewControllers.firstObject isKindOfClass:[NotesTableViewController class]]) {
+                /// The `NotesTableViewController` is wrapped in an `UINavigationController´.
+                con = navigationController.viewControllers.firstObject;
+            }
+        }
+        
+		con.note = sender;
+        con.mapView = _mapView;
 	}
 }
 


### PR DESCRIPTION
Apparently, when tapping a note on the map view, the view
controller that displays the note's comments is presented
inside a `UINavigationController`.

![visible-notes](https://user-images.githubusercontent.com/1681085/73607062-77cdff80-45a9-11ea-9b1a-b341d288ffef.png)

This fixes #254.