### PR TITLE
Refactoring: Move Geekbench score to a dedicated file

### DIFF
--- a/src/Shared/EditorMapLayer.m
+++ b/src/Shared/EditorMapLayer.m
@@ -67,6 +67,9 @@ static const CGFloat Pixels_Per_Character = 8.0;
 }
 @end
 
+@interface EditorMapLayer ()
+
+@end
 
 @implementation EditorMapLayer
 

--- a/src/Shared/EditorMapLayer.m
+++ b/src/Shared/EditorMapLayer.m
@@ -33,6 +33,7 @@
 #import "TagInfo.h"
 #import "VectorMath.h"
 #import "Go_Map__-Swift.h"
+#import "GeekbenchScoreProvider.h"
 
 #define FADE_INOUT			0
 #define SINGLE_SIDED_WALLS	1
@@ -68,6 +69,8 @@ static const CGFloat Pixels_Per_Character = 8.0;
 @end
 
 @interface EditorMapLayer ()
+
+@property (nonatomic) id<GeekbenchScoreProviding> geekbenchScoreProvider;
 
 @end
 

--- a/src/Shared/EditorMapLayer.m
+++ b/src/Shared/EditorMapLayer.m
@@ -6,7 +6,6 @@
 //  Copyright (c) 2012 Bryce Cogswell. All rights reserved.
 //
 
-#import <sys/utsname.h>
 #import <CoreText/CoreText.h>
 
 #import "NSMutableArray+PartialSort.h"
@@ -91,6 +90,7 @@ static const CGFloat NodeHighlightRadius = 6.0;
 	self = [super init];
 	if ( self ) {
 		_mapView = mapView;
+        _geekbenchScoreProvider = [[GeekbenchScoreProvider alloc] init];
 
 		AppDelegate * appDelegate = [AppDelegate getAppDelegate];
 
@@ -963,65 +963,6 @@ static NSInteger ClipLineToRect( OSMPoint p1, OSMPoint p2, OSMRect rect, OSMPoin
 
 #pragma mark Common Drawing
 
--(double)geekbenchScore
-{
-	static double score = 0;
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-		struct utsname systemInfo = { 0 };
-		uname(&systemInfo);
-		NSString * name = [[NSString alloc] initWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
-		NSDictionary * dict = @{
-								@"x86_64"    :	@4000,				// Simulator
-								@"i386"      :	@4000,				// Simulator
-
-								@"iPad5,4"	 :	@0,					// iPad Air 2
-								@"iPad4,5"   :	@2493,				// iPad Mini (2nd Generation iPad Mini - Cellular)
-								@"iPad4,4"   :	@2493,				// iPad Mini (2nd Generation iPad Mini - Wifi)
-								@"iPad4,2"   :	@2664,				// iPad Air 5th Generation iPad (iPad Air) - Cellular
-								@"iPad4,1"   :	@2664,				// iPad Air 5th Generation iPad (iPad Air) - Wifi
-								@"iPad3,6"   :	@1402,				// iPad 4 (4th Generation)
-								@"iPad3,5"   :	@1402,				// iPad 4 (4th Generation)
-								@"iPad3,4"   :	@1402,				// iPad 4 (4th Generation)
-								@"iPad3,3"   :	@492,				// iPad 3 (3rd Generation)
-								@"iPad3,2"   :	@492,				// iPad 3 (3rd Generation)
-								@"iPad3,1"   :	@492,				// iPad 3 (3rd Generation)
-								@"iPad2,7"   :	@490,				// iPad Mini (Original)
-								@"iPad2,6"   :	@490,				// iPad Mini (Original)
-								@"iPad2,5"   :	@490,				// iPad Mini (Original)
-								@"iPad2,4"   :	@492,				// iPad 2
-								@"iPad2,3"   :	@492,				// iPad 2
-								@"iPad2,2"   :	@492,				// iPad 2
-								@"iPad2,1"   :	@492,				// iPad 2
-
-								@"iPhone7,2" :	@2855,				// iPhone 6+
-								@"iPhone7,1" :	@2879,				// iPhone 6
-								@"iPhone6,2" :	@2523,				// iPhone 5s (model A1457, A1518, A1528 (China), A1530 | Global)
-								@"iPhone6,1" :	@2523,				// iPhone 5s model A1433, A1533 | GSM)
-								@"iPhone5,4" :	@1240,				// iPhone 5c (model A1507, A1516, A1526 (China), A1529 | Global)
-								@"iPhone5,3" :	@1240,				// iPhone 5c (model A1456, A1532 | GSM)
-								@"iPhone5,2" :	@1274,				// iPhone 5 (model A1429, everything else)
-								@"iPhone5,1" :	@1274,				// iPhone 5 (model A1428, AT&T/Canada)
-								@"iPhone4,1" :	@405,				// iPhone 4S
-								@"iPhone3,1" :	@206,				// iPhone 4
-								@"iPhone2,1" :	@150,				// iPhone 3GS
-
-								@"iPod4,1"   :	@410,				// iPod Touch (Fifth Generation)
-								@"iPod4,1"   :	@209,				// iPod Touch (Fourth Generation)
-							};
-		NSString * value = [dict objectForKey:name];
-		if ( [value isKindOfClass:[NSNumber class]] ) {
-			score = value.doubleValue;
-		}
-		if ( score == 0 ) {
-			score = 2500;
-		}
-	});
-	return score;
-}
-
-
-
 -(CGPathRef)pathForWay:(OsmWay *)way CF_RETURNS_RETAINED
 {
 	CGMutablePathRef path = CGPathCreateMutable();
@@ -1785,7 +1726,7 @@ const static CGFloat Z_ARROWS			= Z_BASE + 11 * ZSCALE;
 
 -(NSMutableArray *)getShapeLayersForHighlights
 {
-	double				geekScore	= [self geekbenchScore];
+	double				geekScore	= [self.geekbenchScoreProvider geekbenchScore];
 	NSInteger			nameLimit	= 5 + (geekScore - 500) / 200;	// 500 -> 5, 2500 -> 10
 	NSMutableSet	*	nameSet		= [NSMutableSet new];
 	NSMutableArray	*	layers		= [NSMutableArray new];
@@ -1990,7 +1931,7 @@ const static CGFloat Z_ARROWS			= Z_BASE + 11 * ZSCALE;
  @return The value to use for the text layer's `shouldRasterize` property.
  */
 - (BOOL)shouldRasterizeStreetNames {
-    return [self geekbenchScore] < 2500;
+    return [self.geekbenchScoreProvider geekbenchScore] < 2500;
 }
 
 -(void)resetDisplayLayers
@@ -2299,7 +2240,7 @@ static BOOL VisibleSizeLessStrict( OsmBaseObject * obj1, OsmBaseObject * obj2 )
 - (NSMutableArray *)getObjectsToDisplay
 {
 #if TARGET_OS_IPHONE
-	double geekScore = [self geekbenchScore];
+	double geekScore = [self.geekbenchScoreProvider geekbenchScore];
 	NSInteger objectLimit = 50 + (geekScore - 500) / 40;	// 500 -> 50, 2500 -> 100;
 #else
 	NSInteger objectLimit = 500;

--- a/src/iOS/GeekbenchScoreProvider.h
+++ b/src/iOS/GeekbenchScoreProvider.h
@@ -1,0 +1,17 @@
+//
+//  GeekbenchScoreProvider.h
+//  Go Map!!
+//
+//  Created by Wolfgang Timme on 2/16/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GeekbenchScoreProvider : NSObject
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/iOS/GeekbenchScoreProvider.h
+++ b/src/iOS/GeekbenchScoreProvider.h
@@ -10,6 +10,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@protocol GeekbenchScoreProviding
+
+- (double)geekbenchScore;
+
+@end
+
 @interface GeekbenchScoreProvider : NSObject
 
 @end

--- a/src/iOS/GeekbenchScoreProvider.h
+++ b/src/iOS/GeekbenchScoreProvider.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface GeekbenchScoreProvider : NSObject
+@interface GeekbenchScoreProvider : NSObject <GeekbenchScoreProviding>
 
 @end
 

--- a/src/iOS/GeekbenchScoreProvider.m
+++ b/src/iOS/GeekbenchScoreProvider.m
@@ -1,0 +1,13 @@
+//
+//  GeekbenchScoreProvider.m
+//  Go Map!!
+//
+//  Created by Wolfgang Timme on 2/16/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+#import "GeekbenchScoreProvider.h"
+
+@implementation GeekbenchScoreProvider
+
+@end

--- a/src/iOS/GeekbenchScoreProvider.m
+++ b/src/iOS/GeekbenchScoreProvider.m
@@ -8,6 +8,65 @@
 
 #import "GeekbenchScoreProvider.h"
 
+#import <sys/utsname.h>
+
 @implementation GeekbenchScoreProvider
+
+-(double)geekbenchScore
+{
+    static double score = 0;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        struct utsname systemInfo = { 0 };
+        uname(&systemInfo);
+        NSString * name = [[NSString alloc] initWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
+        NSDictionary * dict = @{
+                                @"x86_64"    :    @4000,                // Simulator
+                                @"i386"      :    @4000,                // Simulator
+
+                                @"iPad5,4"     :    @0,                    // iPad Air 2
+                                @"iPad4,5"   :    @2493,                // iPad Mini (2nd Generation iPad Mini - Cellular)
+                                @"iPad4,4"   :    @2493,                // iPad Mini (2nd Generation iPad Mini - Wifi)
+                                @"iPad4,2"   :    @2664,                // iPad Air 5th Generation iPad (iPad Air) - Cellular
+                                @"iPad4,1"   :    @2664,                // iPad Air 5th Generation iPad (iPad Air) - Wifi
+                                @"iPad3,6"   :    @1402,                // iPad 4 (4th Generation)
+                                @"iPad3,5"   :    @1402,                // iPad 4 (4th Generation)
+                                @"iPad3,4"   :    @1402,                // iPad 4 (4th Generation)
+                                @"iPad3,3"   :    @492,                // iPad 3 (3rd Generation)
+                                @"iPad3,2"   :    @492,                // iPad 3 (3rd Generation)
+                                @"iPad3,1"   :    @492,                // iPad 3 (3rd Generation)
+                                @"iPad2,7"   :    @490,                // iPad Mini (Original)
+                                @"iPad2,6"   :    @490,                // iPad Mini (Original)
+                                @"iPad2,5"   :    @490,                // iPad Mini (Original)
+                                @"iPad2,4"   :    @492,                // iPad 2
+                                @"iPad2,3"   :    @492,                // iPad 2
+                                @"iPad2,2"   :    @492,                // iPad 2
+                                @"iPad2,1"   :    @492,                // iPad 2
+
+                                @"iPhone7,2" :    @2855,                // iPhone 6+
+                                @"iPhone7,1" :    @2879,                // iPhone 6
+                                @"iPhone6,2" :    @2523,                // iPhone 5s (model A1457, A1518, A1528 (China), A1530 | Global)
+                                @"iPhone6,1" :    @2523,                // iPhone 5s model A1433, A1533 | GSM)
+                                @"iPhone5,4" :    @1240,                // iPhone 5c (model A1507, A1516, A1526 (China), A1529 | Global)
+                                @"iPhone5,3" :    @1240,                // iPhone 5c (model A1456, A1532 | GSM)
+                                @"iPhone5,2" :    @1274,                // iPhone 5 (model A1429, everything else)
+                                @"iPhone5,1" :    @1274,                // iPhone 5 (model A1428, AT&T/Canada)
+                                @"iPhone4,1" :    @405,                // iPhone 4S
+                                @"iPhone3,1" :    @206,                // iPhone 4
+                                @"iPhone2,1" :    @150,                // iPhone 3GS
+
+                                @"iPod4,1"   :    @410,                // iPod Touch (Fifth Generation)
+                                @"iPod4,1"   :    @209,                // iPod Touch (Fourth Generation)
+                            };
+        NSString * value = [dict objectForKey:name];
+        if ( [value isKindOfClass:[NSNumber class]] ) {
+            score = value.doubleValue;
+        }
+        if ( score == 0 ) {
+            score = 2500;
+        }
+    });
+    return score;
+}
 
 @end

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -504,6 +504,7 @@
 		6442666722540EDF00C0D545 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6442666422540EDF00C0D545 /* Lock.swift */; };
 		6442666822540EDF00C0D545 /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6442666522540EDF00C0D545 /* Disposable.swift */; };
 		6442666922540EDF00C0D545 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6442666622540EDF00C0D545 /* Observable.swift */; };
+		6463E3CB23F948FE00E4F6ED /* GeekbenchScoreProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 6463E3CA23F948FE00E4F6ED /* GeekbenchScoreProvider.m */; };
 		647F46CE2253EA4C00CEC482 /* MeasureDirectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647F46CD2253EA4C00CEC482 /* MeasureDirectionViewModel.swift */; };
 		647F46D12253F08200CEC482 /* HeadingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647F46D02253F08200CEC482 /* HeadingProvider.swift */; };
 		64C968452261ED3100351C0C /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 64C968442261ED3100351C0C /* Media.xcassets */; };
@@ -1131,6 +1132,8 @@
 		6442666422540EDF00C0D545 /* Lock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		6442666522540EDF00C0D545 /* Disposable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Disposable.swift; sourceTree = "<group>"; };
 		6442666622540EDF00C0D545 /* Observable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
+		6463E3C923F948FE00E4F6ED /* GeekbenchScoreProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeekbenchScoreProvider.h; sourceTree = "<group>"; };
+		6463E3CA23F948FE00E4F6ED /* GeekbenchScoreProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GeekbenchScoreProvider.m; sourceTree = "<group>"; };
 		647F46CD2253EA4C00CEC482 /* MeasureDirectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureDirectionViewModel.swift; sourceTree = "<group>"; };
 		647F46D02253F08200CEC482 /* HeadingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadingProvider.swift; sourceTree = "<group>"; };
 		64C968442261ED3100351C0C /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
@@ -1467,6 +1470,8 @@
 				02BED988168B6F2F00357B94 /* WebPageViewController.h */,
 				02BED989168B6F2F00357B94 /* WebPageViewController.m */,
 				64C968442261ED3100351C0C /* Media.xcassets */,
+				6463E3C923F948FE00E4F6ED /* GeekbenchScoreProvider.h */,
+				6463E3CA23F948FE00E4F6ED /* GeekbenchScoreProvider.m */,
 			);
 			name = "Go Map!";
 			sourceTree = "<group>";
@@ -2578,6 +2583,7 @@
 				64981F1F22667D7700178476 /* SettingsViewController.swift in Sources */,
 				02BED99F168D102700357B94 /* OfflineViewController.m in Sources */,
 				02401F391DE1369E00F32AF5 /* ExternalGPS.m in Sources */,
+				6463E3CB23F948FE00E4F6ED /* GeekbenchScoreProvider.m in Sources */,
 				02F8F4341696004B002A0820 /* NominatumViewController.m in Sources */,
 				02C19B351699E8C000F75E3C /* BingMetadataViewController.m in Sources */,
 				028E0C0C20B2182100CEC71F /* FilterObjectsViewController.m in Sources */,


### PR DESCRIPTION
This branch moves the method that determines the Geekbench score from `EditorMapLayer` to a dedicated file.

The goal of these changes is to reduce the number of lines in `EditorMapLayer` so that it is easier to read and maintain. Furthermore, by having this code in a dedicated file, it can be used in other places, e. g. new layers.