### PR TITLE
Remove debug `NSLog` from `FpsLabel`

### DIFF
--- a/src/iOS/FpsLabel.m
+++ b/src/iOS/FpsLabel.m
@@ -94,7 +94,6 @@ const int FRAME_COUNT = 60;
 		self.text = [NSString stringWithFormat:@"%.1f FPS", average];
 	else
 		self.text = [NSString stringWithFormat:@"%.2f FPS", average];
-	NSLog(@"frame");
 }
 
 - (void)frameUpdated


### PR DESCRIPTION
With this branch, I remove a debug log from the `FpsLabel` that is printed whenever the map moves.

I like to monitor the FPS of the map, so I have the label visible at all times. That's when I noticed that the log was being filled with the message "frame". This seems to make the Simulator run slower, and the log is barely usable anymore.