### PR TITLE
Refactoring: Improve interface of `Database`

### DIFF
--- a/src/Shared/Database.h
+++ b/src/Shared/Database.h
@@ -28,7 +28,7 @@
 -(void)dropTables;
 
 -(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray<OsmRelation *> *)saveRelations
-		deleteNodes:(NSArray *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
+		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
 		isUpdate:(BOOL)isUpdate;
 
 -(NSMutableDictionary<NSNumber *, OsmNode *> *)querySqliteNodes;

--- a/src/Shared/Database.h
+++ b/src/Shared/Database.h
@@ -27,7 +27,7 @@
 -(void)createTables;
 -(void)dropTables;
 
--(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray *)saveWays saveRelations:(NSArray *)saveRelations
+-(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray *)saveRelations
 		deleteNodes:(NSArray *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
 		isUpdate:(BOOL)isUpdate;
 

--- a/src/Shared/Database.h
+++ b/src/Shared/Database.h
@@ -28,7 +28,7 @@
 -(void)dropTables;
 
 -(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray<OsmRelation *> *)saveRelations
-		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
+		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray<OsmWay *> *)deleteWays deleteRelations:(NSArray *)deleteRelations
 		isUpdate:(BOOL)isUpdate;
 
 -(NSMutableDictionary<NSNumber *, OsmNode *> *)querySqliteNodes;

--- a/src/Shared/Database.h
+++ b/src/Shared/Database.h
@@ -31,7 +31,7 @@
 		deleteNodes:(NSArray *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
 		isUpdate:(BOOL)isUpdate;
 
--(NSMutableDictionary *)querySqliteNodes;
+-(NSMutableDictionary<NSNumber *, OsmNode *> *)querySqliteNodes;
 -(NSMutableDictionary *)querySqliteWays;
 -(NSMutableDictionary *)querySqliteRelations;
 

--- a/src/Shared/Database.h
+++ b/src/Shared/Database.h
@@ -27,7 +27,7 @@
 -(void)createTables;
 -(void)dropTables;
 
--(BOOL)saveNodes:(NSArray *)saveNodes saveWays:(NSArray *)saveWays saveRelations:(NSArray *)saveRelations
+-(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray *)saveWays saveRelations:(NSArray *)saveRelations
 		deleteNodes:(NSArray *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
 		isUpdate:(BOOL)isUpdate;
 

--- a/src/Shared/Database.h
+++ b/src/Shared/Database.h
@@ -33,6 +33,6 @@
 
 -(NSMutableDictionary<NSNumber *, OsmNode *> *)querySqliteNodes;
 -(NSMutableDictionary<NSNumber *, OsmWay *> *)querySqliteWays;
--(NSMutableDictionary *)querySqliteRelations;
+-(NSMutableDictionary<NSNumber *, OsmRelation *> *)querySqliteRelations;
 
 @end

--- a/src/Shared/Database.h
+++ b/src/Shared/Database.h
@@ -27,9 +27,13 @@
 -(void)createTables;
 -(void)dropTables;
 
--(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray<OsmRelation *> *)saveRelations
-		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray<OsmWay *> *)deleteWays deleteRelations:(NSArray<OsmRelation *> *)deleteRelations
-		isUpdate:(BOOL)isUpdate;
+-(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes
+        saveWays:(NSArray<OsmWay *> *)saveWays
+   saveRelations:(NSArray<OsmRelation *> *)saveRelations
+     deleteNodes:(NSArray<OsmNode *> *)deleteNodes
+      deleteWays:(NSArray<OsmWay *> *)deleteWays
+ deleteRelations:(NSArray<OsmRelation *> *)deleteRelations
+        isUpdate:(BOOL)isUpdate;
 
 -(NSMutableDictionary<NSNumber *, OsmNode *> *)querySqliteNodes;
 -(NSMutableDictionary<NSNumber *, OsmWay *> *)querySqliteWays;

--- a/src/Shared/Database.h
+++ b/src/Shared/Database.h
@@ -32,7 +32,7 @@
 		isUpdate:(BOOL)isUpdate;
 
 -(NSMutableDictionary<NSNumber *, OsmNode *> *)querySqliteNodes;
--(NSMutableDictionary *)querySqliteWays;
+-(NSMutableDictionary<NSNumber *, OsmWay *> *)querySqliteWays;
 -(NSMutableDictionary *)querySqliteRelations;
 
 @end

--- a/src/Shared/Database.h
+++ b/src/Shared/Database.h
@@ -27,7 +27,7 @@
 -(void)createTables;
 -(void)dropTables;
 
--(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray *)saveRelations
+-(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray<OsmRelation *> *)saveRelations
 		deleteNodes:(NSArray *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
 		isUpdate:(BOOL)isUpdate;
 

--- a/src/Shared/Database.h
+++ b/src/Shared/Database.h
@@ -28,7 +28,7 @@
 -(void)dropTables;
 
 -(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray<OsmRelation *> *)saveRelations
-		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray<OsmWay *> *)deleteWays deleteRelations:(NSArray *)deleteRelations
+		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray<OsmWay *> *)deleteWays deleteRelations:(NSArray<OsmRelation *> *)deleteRelations
 		isUpdate:(BOOL)isUpdate;
 
 -(NSMutableDictionary<NSNumber *, OsmNode *> *)querySqliteNodes;

--- a/src/Shared/Database.m
+++ b/src/Shared/Database.m
@@ -566,7 +566,7 @@ retry:
 	return rc == SQLITE_OK || rc == SQLITE_DONE;
 }
 
--(BOOL)deleteRelations:(NSArray *)relations
+-(BOOL)deleteRelations:(NSArray<OsmRelation *> *)relations
 {
 	if ( relations.count == 0 )
 		return YES;
@@ -595,7 +595,7 @@ retry:
 #pragma mark update
 
 -(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray<OsmRelation *> *)saveRelations
-		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray<OsmWay *> *)deleteWays deleteRelations:(NSArray *)deleteRelations
+		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray<OsmWay *> *)deleteWays deleteRelations:(NSArray<OsmRelation *> *)deleteRelations
 		isUpdate:(BOOL)isUpdate
 {
 #if 0 && DEBUG

--- a/src/Shared/Database.m
+++ b/src/Shared/Database.m
@@ -594,9 +594,13 @@ retry:
 
 #pragma mark update
 
--(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray<OsmRelation *> *)saveRelations
-		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray<OsmWay *> *)deleteWays deleteRelations:(NSArray<OsmRelation *> *)deleteRelations
-		isUpdate:(BOOL)isUpdate
+-(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes
+        saveWays:(NSArray<OsmWay *> *)saveWays
+   saveRelations:(NSArray<OsmRelation *> *)saveRelations
+     deleteNodes:(NSArray<OsmNode *> *)deleteNodes
+      deleteWays:(NSArray<OsmWay *> *)deleteWays
+ deleteRelations:(NSArray<OsmRelation *> *)deleteRelations
+        isUpdate:(BOOL)isUpdate
 {
 #if 0 && DEBUG
 	assert( dispatch_get_current_queue() == Database.dispatchQueue );

--- a/src/Shared/Database.m
+++ b/src/Shared/Database.m
@@ -802,7 +802,7 @@ retry:
 }
 
 
--(NSMutableDictionary *)querySqliteRelations
+-(NSMutableDictionary<NSNumber *, OsmRelation *> *)querySqliteRelations
 {
 	if ( _db == NULL )
 		return nil;
@@ -814,7 +814,7 @@ retry:
 	if ( rc != SQLITE_OK )
 		return nil;
 
-	NSMutableDictionary * relations = [NSMutableDictionary new];
+	NSMutableDictionary<NSNumber *, OsmRelation *> * relations = [NSMutableDictionary new];
 	while ( (rc = sqlite3_step(relationStatement)) == SQLITE_ROW )  {
 		int64_t			ident		= sqlite3_column_int64(relationStatement, 0);
 		const uint8_t *	user		= sqlite3_column_text(relationStatement, 1);

--- a/src/Shared/Database.m
+++ b/src/Shared/Database.m
@@ -720,14 +720,14 @@ retry:
 	return rc == SQLITE_OK ? nodes : nil;
 }
 
--(NSMutableDictionary *)querySqliteWays
+-(NSMutableDictionary<NSNumber *, OsmWay *> *)querySqliteWays
 {
 	if ( _db == NULL )
 		return nil;
 
 	int rc = SQLITE_OK;
 	sqlite3_stmt * wayStatement = NULL;
-	NSMutableDictionary * ways = [NSMutableDictionary new];
+	NSMutableDictionary<NSNumber *, OsmWay *> * ways = [NSMutableDictionary new];
 
 	rc = sqlite3_prepare_v2( _db, "SELECT ident,user,timestamp,version,changeset,uid,nodecount FROM ways", -1, &wayStatement, nil );
 	if ( rc != SQLITE_OK )

--- a/src/Shared/Database.m
+++ b/src/Shared/Database.m
@@ -433,7 +433,7 @@ retry:
 }
 
 
--(BOOL)saveRelations:(NSArray *)relations
+-(BOOL)saveRelations:(NSArray<OsmRelation *> *)relations
 {
 	__block int rc = SQLITE_OK;
 
@@ -594,7 +594,7 @@ retry:
 
 #pragma mark update
 
--(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray *)saveRelations
+-(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray<OsmRelation *> *)saveRelations
 		deleteNodes:(NSArray *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
 		isUpdate:(BOOL)isUpdate
 {

--- a/src/Shared/Database.m
+++ b/src/Shared/Database.m
@@ -677,7 +677,7 @@ retry:
 	return rc == SQLITE_OK;
 }
 
--(NSMutableDictionary *)querySqliteNodes
+-(NSMutableDictionary<NSNumber *, OsmNode *> *)querySqliteNodes
 {
 	if ( _db == NULL )
 		return nil;
@@ -688,7 +688,7 @@ retry:
 	if ( rc != SQLITE_OK )
 		return nil;
 
-	NSMutableDictionary * nodes = [NSMutableDictionary new];
+	NSMutableDictionary<NSNumber *, OsmNode *> * nodes = [NSMutableDictionary new];
 	
 	while ( (rc = sqlite3_step(nodeStatement)) == SQLITE_ROW )  {
 		int64_t			ident		= sqlite3_column_int64(nodeStatement, 0);

--- a/src/Shared/Database.m
+++ b/src/Shared/Database.m
@@ -292,7 +292,7 @@ retry:
 
 #pragma mark save
 
--(BOOL)saveNodes:(NSArray *)nodes
+-(BOOL)saveNodes:(NSArray<OsmNode *> *)nodes
 {
 	__block int rc = SQLITE_OK;
 
@@ -594,7 +594,7 @@ retry:
 
 #pragma mark update
 
--(BOOL)saveNodes:(NSArray *)saveNodes saveWays:(NSArray *)saveWays saveRelations:(NSArray *)saveRelations
+-(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray *)saveWays saveRelations:(NSArray *)saveRelations
 		deleteNodes:(NSArray *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
 		isUpdate:(BOOL)isUpdate
 {

--- a/src/Shared/Database.m
+++ b/src/Shared/Database.m
@@ -540,7 +540,7 @@ retry:
 	return rc == SQLITE_OK || rc == SQLITE_DONE;
 }
 
--(BOOL)deleteWays:(NSArray *)ways
+-(BOOL)deleteWays:(NSArray<OsmWay *> *)ways
 {
 	if ( ways.count == 0 )
 		return YES;
@@ -595,7 +595,7 @@ retry:
 #pragma mark update
 
 -(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray<OsmRelation *> *)saveRelations
-		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
+		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray<OsmWay *> *)deleteWays deleteRelations:(NSArray *)deleteRelations
 		isUpdate:(BOOL)isUpdate
 {
 #if 0 && DEBUG

--- a/src/Shared/Database.m
+++ b/src/Shared/Database.m
@@ -357,7 +357,7 @@ retry:
 	return rc == SQLITE_OK || rc == SQLITE_DONE;
 }
 
--(BOOL)saveWays:(NSArray *)ways
+-(BOOL)saveWays:(NSArray<OsmWay *> *)ways
 {
 	__block int rc = SQLITE_OK;
 
@@ -594,7 +594,7 @@ retry:
 
 #pragma mark update
 
--(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray *)saveWays saveRelations:(NSArray *)saveRelations
+-(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray *)saveRelations
 		deleteNodes:(NSArray *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
 		isUpdate:(BOOL)isUpdate
 {

--- a/src/Shared/Database.m
+++ b/src/Shared/Database.m
@@ -514,7 +514,7 @@ retry:
 
 #pragma mark delete
 
--(BOOL)deleteNodes:(NSArray *)nodes
+-(BOOL)deleteNodes:(NSArray<OsmNode *> *)nodes
 {
 	if ( nodes.count == 0 )
 		return YES;
@@ -595,7 +595,7 @@ retry:
 #pragma mark update
 
 -(BOOL)saveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray<OsmRelation *> *)saveRelations
-		deleteNodes:(NSArray *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
+		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
 		isUpdate:(BOOL)isUpdate
 {
 #if 0 && DEBUG

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -2398,7 +2398,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 		BOOL databaseFailure = NO;
 		@try {
 			Database * db = [Database new];
-			NSMutableDictionary * newNodes		= [db querySqliteNodes];
+			NSMutableDictionary<NSNumber *, OsmNode *> * newNodes		= [db querySqliteNodes];
 			NSAssert(newNodes,nil);
 			NSMutableDictionary * newWays		= [db querySqliteWays];
 			NSAssert(newWays,nil);

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -2111,7 +2111,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 }
 
 -(void)sqlSaveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray<OsmRelation *> *)saveRelations
-		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
+		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray<OsmWay *> *)deleteWays deleteRelations:(NSArray *)deleteRelations
 		   isUpdate:(BOOL)isUpdate
 {
 	if ( saveNodes.count + saveWays.count + saveRelations.count + deleteNodes.count + deleteWays.count + deleteRelations.count == 0 )
@@ -2326,7 +2326,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 	NSMutableArray<OsmWay *> * insertWay		= [NSMutableArray new];
     NSMutableArray<OsmRelation *> * insertRelation    = [NSMutableArray new];
 	NSMutableArray<OsmNode *> * deleteNode		= [NSMutableArray new];
-	NSMutableArray * deleteWay		= [NSMutableArray new];
+	NSMutableArray<OsmWay *> * deleteWay		= [NSMutableArray new];
 	NSMutableArray * deleteRelation	= [NSMutableArray new];
 	[sqlUpdate enumerateKeysAndObjectsUsingBlock:^(OsmBaseObject * object, NSNumber * insert, BOOL *stop) {
 		if ( object.isNode ) {
@@ -2338,7 +2338,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 			if ( insert.boolValue )
 				[insertWay addObject:object.isWay];
 			else
-				[deleteWay addObject:object];
+				[deleteWay addObject:object.isWay];
 		} else if ( object.isRelation ) {
 			if ( insert.boolValue )
 				[insertRelation addObject:object.isRelation];

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -1106,7 +1106,13 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 
 		// store new nodes in database
 		if ( downloaded ) {
-			[self sqlSaveNodes:newNodes saveWays:newWays saveRelations:newRelations deleteNodes:nil deleteWays:nil deleteRelations:nil isUpdate:NO];
+			[self sqlSaveNodes:newNodes
+                      saveWays:newWays
+                 saveRelations:newRelations
+                   deleteNodes:nil
+                    deleteWays:nil
+               deleteRelations:nil
+                      isUpdate:NO];
 
 			// purge old data
 			dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
@@ -2110,9 +2116,13 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 	return ok;
 }
 
--(void)sqlSaveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray<OsmRelation *> *)saveRelations
-		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray<OsmWay *> *)deleteWays deleteRelations:(NSArray<OsmRelation *> *)deleteRelations
-		   isUpdate:(BOOL)isUpdate
+-(void)sqlSaveNodes:(NSArray<OsmNode *> *)saveNodes
+           saveWays:(NSArray<OsmWay *> *)saveWays
+      saveRelations:(NSArray<OsmRelation *> *)saveRelations
+        deleteNodes:(NSArray<OsmNode *> *)deleteNodes
+         deleteWays:(NSArray<OsmWay *> *)deleteWays
+    deleteRelations:(NSArray<OsmRelation *> *)deleteRelations
+           isUpdate:(BOOL)isUpdate
 {
 	if ( saveNodes.count + saveWays.count + saveRelations.count + deleteNodes.count + deleteWays.count + deleteRelations.count == 0 )
 		return;
@@ -2123,7 +2133,13 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 		{
 			Database * db = [Database new];
 			[db createTables];
-			ok = [db saveNodes:saveNodes saveWays:saveWays saveRelations:saveRelations deleteNodes:deleteNodes deleteWays:deleteWays deleteRelations:deleteRelations isUpdate:isUpdate];
+			ok = [db saveNodes:saveNodes
+                      saveWays:saveWays
+                 saveRelations:saveRelations
+                   deleteNodes:deleteNodes
+                    deleteWays:deleteWays
+               deleteRelations:deleteRelations
+                      isUpdate:isUpdate];
 			if ( !ok ) {
 				[Database deleteDatabaseWithName:nil];
 			}
@@ -2296,8 +2312,13 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 			Database * db2 = [[Database alloc] initWithName:@"tmp"];
 			tmpPath = db2.path;
 			[db2 createTables];
-			[db2 saveNodes:saveNodes saveWays:saveWays saveRelations:saveRelations
-			   deleteNodes:nil deleteWays:nil deleteRelations:nil isUpdate:NO];
+			[db2 saveNodes:saveNodes
+                  saveWays:saveWays
+             saveRelations:saveRelations
+               deleteNodes:nil
+                deleteWays:nil
+           deleteRelations:nil
+                  isUpdate:NO];
 		}
 		
 		NSString * realPath = [Database databasePathWithName:nil];
@@ -2348,7 +2369,13 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 			assert(NO);
 		}
 	}];
-	[self sqlSaveNodes:insertNode saveWays:insertWay saveRelations:insertRelation deleteNodes:deleteNode deleteWays:deleteWay deleteRelations:deleteRelation isUpdate:YES];
+	[self sqlSaveNodes:insertNode
+              saveWays:insertWay
+         saveRelations:insertRelation
+           deleteNodes:deleteNode
+            deleteWays:deleteWay
+       deleteRelations:deleteRelation
+              isUpdate:YES];
 }
 
 

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -2400,7 +2400,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 			Database * db = [Database new];
 			NSMutableDictionary<NSNumber *, OsmNode *> * newNodes		= [db querySqliteNodes];
 			NSAssert(newNodes,nil);
-			NSMutableDictionary * newWays		= [db querySqliteWays];
+			NSMutableDictionary<NSNumber *, OsmWay *> * newWays		= [db querySqliteWays];
 			NSAssert(newWays,nil);
 			NSMutableDictionary * newRelations	= [db querySqliteRelations];
 			NSAssert(newRelations,nil);

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -1038,7 +1038,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 	if ( newData ) {
 
 		NSMutableArray<OsmNode *> * newNodes = [NSMutableArray new];
-		NSMutableArray * newWays = [NSMutableArray new];
+		NSMutableArray<OsmWay *> * newWays = [NSMutableArray new];
 		NSMutableArray * newRelations = [NSMutableArray new];
 
 		[newData->_nodes enumerateKeysAndObjectsUsingBlock:^(NSNumber * key,OsmNode * node,BOOL * stop){
@@ -2110,7 +2110,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 	return ok;
 }
 
--(void)sqlSaveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray *)saveWays saveRelations:(NSArray *)saveRelations
+-(void)sqlSaveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray *)saveRelations
 		deleteNodes:(NSArray *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
 		   isUpdate:(BOOL)isUpdate
 {
@@ -2283,7 +2283,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 
 	// make a copy of items to save because the dictionary might get updated by the time the Database block runs
 	NSArray<OsmNode *> * saveNodes 	= [_nodes allValues];
-	NSArray * saveWays 		= [_ways allValues];
+	NSArray<OsmWay *> * saveWays 		= [_ways allValues];
 	NSArray * saveRelations = [_relations allValues];
 	
 	dispatch_async(Database.dispatchQueue, ^{
@@ -2323,7 +2323,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 -(void)updateSql:(NSDictionary *)sqlUpdate
 {
 	NSMutableArray<OsmNode *> * insertNode		= [NSMutableArray new];
-	NSMutableArray * insertWay		= [NSMutableArray new];
+	NSMutableArray<OsmWay *> * insertWay		= [NSMutableArray new];
 	NSMutableArray * insertRelation	= [NSMutableArray new];
 	NSMutableArray * deleteNode		= [NSMutableArray new];
 	NSMutableArray * deleteWay		= [NSMutableArray new];
@@ -2336,7 +2336,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 				[deleteNode addObject:object];
 		} else if ( object.isWay ) {
 			if ( insert.boolValue )
-				[insertWay addObject:object];
+				[insertWay addObject:object.isWay];
 			else
 				[deleteWay addObject:object];
 		} else if ( object.isRelation ) {

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -2111,7 +2111,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 }
 
 -(void)sqlSaveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray<OsmRelation *> *)saveRelations
-		deleteNodes:(NSArray *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
+		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
 		   isUpdate:(BOOL)isUpdate
 {
 	if ( saveNodes.count + saveWays.count + saveRelations.count + deleteNodes.count + deleteWays.count + deleteRelations.count == 0 )
@@ -2325,7 +2325,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 	NSMutableArray<OsmNode *> * insertNode		= [NSMutableArray new];
 	NSMutableArray<OsmWay *> * insertWay		= [NSMutableArray new];
     NSMutableArray<OsmRelation *> * insertRelation    = [NSMutableArray new];
-	NSMutableArray * deleteNode		= [NSMutableArray new];
+	NSMutableArray<OsmNode *> * deleteNode		= [NSMutableArray new];
 	NSMutableArray * deleteWay		= [NSMutableArray new];
 	NSMutableArray * deleteRelation	= [NSMutableArray new];
 	[sqlUpdate enumerateKeysAndObjectsUsingBlock:^(OsmBaseObject * object, NSNumber * insert, BOOL *stop) {
@@ -2333,7 +2333,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 			if ( insert.boolValue )
 				[insertNode addObject:object.isNode];
 			else
-				[deleteNode addObject:object];
+				[deleteNode addObject:object.isNode];
 		} else if ( object.isWay ) {
 			if ( insert.boolValue )
 				[insertWay addObject:object.isWay];

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -2111,7 +2111,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 }
 
 -(void)sqlSaveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray<OsmRelation *> *)saveRelations
-		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray<OsmWay *> *)deleteWays deleteRelations:(NSArray *)deleteRelations
+		deleteNodes:(NSArray<OsmNode *> *)deleteNodes deleteWays:(NSArray<OsmWay *> *)deleteWays deleteRelations:(NSArray<OsmRelation *> *)deleteRelations
 		   isUpdate:(BOOL)isUpdate
 {
 	if ( saveNodes.count + saveWays.count + saveRelations.count + deleteNodes.count + deleteWays.count + deleteRelations.count == 0 )
@@ -2327,7 +2327,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
     NSMutableArray<OsmRelation *> * insertRelation    = [NSMutableArray new];
 	NSMutableArray<OsmNode *> * deleteNode		= [NSMutableArray new];
 	NSMutableArray<OsmWay *> * deleteWay		= [NSMutableArray new];
-	NSMutableArray * deleteRelation	= [NSMutableArray new];
+	NSMutableArray<OsmRelation *> * deleteRelation	= [NSMutableArray new];
 	[sqlUpdate enumerateKeysAndObjectsUsingBlock:^(OsmBaseObject * object, NSNumber * insert, BOOL *stop) {
 		if ( object.isNode ) {
 			if ( insert.boolValue )
@@ -2343,7 +2343,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 			if ( insert.boolValue )
 				[insertRelation addObject:object.isRelation];
 			else
-				[deleteRelation addObject:object];
+				[deleteRelation addObject:object.isRelation];
 		} else {
 			assert(NO);
 		}

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -2402,7 +2402,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 			NSAssert(newNodes,nil);
 			NSMutableDictionary<NSNumber *, OsmWay *> * newWays		= [db querySqliteWays];
 			NSAssert(newWays,nil);
-			NSMutableDictionary * newRelations	= [db querySqliteRelations];
+			NSMutableDictionary<NSNumber *, OsmRelation *> * newRelations	= [db querySqliteRelations];
 			NSAssert(newRelations,nil);
 
 			OsmMapData * newData = [[OsmMapData alloc] init];

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -1037,7 +1037,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 {
 	if ( newData ) {
 
-		NSMutableArray * newNodes = [NSMutableArray new];
+		NSMutableArray<OsmNode *> * newNodes = [NSMutableArray new];
 		NSMutableArray * newWays = [NSMutableArray new];
 		NSMutableArray * newRelations = [NSMutableArray new];
 
@@ -2110,7 +2110,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 	return ok;
 }
 
--(void)sqlSaveNodes:(NSArray *)saveNodes saveWays:(NSArray *)saveWays saveRelations:(NSArray *)saveRelations
+-(void)sqlSaveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray *)saveWays saveRelations:(NSArray *)saveRelations
 		deleteNodes:(NSArray *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
 		   isUpdate:(BOOL)isUpdate
 {
@@ -2282,7 +2282,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 	NSLog(@"Discard sweep time = %f\n",t);
 
 	// make a copy of items to save because the dictionary might get updated by the time the Database block runs
-	NSArray * saveNodes 	= [_nodes allValues];
+	NSArray<OsmNode *> * saveNodes 	= [_nodes allValues];
 	NSArray * saveWays 		= [_ways allValues];
 	NSArray * saveRelations = [_relations allValues];
 	
@@ -2322,7 +2322,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 // after uploading a changeset we have to update the SQL database to reflect the changes the server replied with
 -(void)updateSql:(NSDictionary *)sqlUpdate
 {
-	NSMutableArray * insertNode		= [NSMutableArray new];
+	NSMutableArray<OsmNode *> * insertNode		= [NSMutableArray new];
 	NSMutableArray * insertWay		= [NSMutableArray new];
 	NSMutableArray * insertRelation	= [NSMutableArray new];
 	NSMutableArray * deleteNode		= [NSMutableArray new];
@@ -2331,7 +2331,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 	[sqlUpdate enumerateKeysAndObjectsUsingBlock:^(OsmBaseObject * object, NSNumber * insert, BOOL *stop) {
 		if ( object.isNode ) {
 			if ( insert.boolValue )
-				[insertNode addObject:object];
+				[insertNode addObject:object.isNode];
 			else
 				[deleteNode addObject:object];
 		} else if ( object.isWay ) {

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -1039,7 +1039,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 
 		NSMutableArray<OsmNode *> * newNodes = [NSMutableArray new];
 		NSMutableArray<OsmWay *> * newWays = [NSMutableArray new];
-		NSMutableArray * newRelations = [NSMutableArray new];
+		NSMutableArray<OsmRelation *> * newRelations = [NSMutableArray new];
 
 		[newData->_nodes enumerateKeysAndObjectsUsingBlock:^(NSNumber * key,OsmNode * node,BOOL * stop){
 			OsmNode * current = [_nodes objectForKey:key];
@@ -2110,7 +2110,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 	return ok;
 }
 
--(void)sqlSaveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray *)saveRelations
+-(void)sqlSaveNodes:(NSArray<OsmNode *> *)saveNodes saveWays:(NSArray<OsmWay *> *)saveWays saveRelations:(NSArray<OsmRelation *> *)saveRelations
 		deleteNodes:(NSArray *)deleteNodes deleteWays:(NSArray *)deleteWays deleteRelations:(NSArray *)deleteRelations
 		   isUpdate:(BOOL)isUpdate
 {
@@ -2284,7 +2284,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 	// make a copy of items to save because the dictionary might get updated by the time the Database block runs
 	NSArray<OsmNode *> * saveNodes 	= [_nodes allValues];
 	NSArray<OsmWay *> * saveWays 		= [_ways allValues];
-	NSArray * saveRelations = [_relations allValues];
+	NSArray<OsmRelation *> * saveRelations = [_relations allValues];
 	
 	dispatch_async(Database.dispatchQueue, ^{
 		
@@ -2324,7 +2324,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 {
 	NSMutableArray<OsmNode *> * insertNode		= [NSMutableArray new];
 	NSMutableArray<OsmWay *> * insertWay		= [NSMutableArray new];
-	NSMutableArray * insertRelation	= [NSMutableArray new];
+    NSMutableArray<OsmRelation *> * insertRelation    = [NSMutableArray new];
 	NSMutableArray * deleteNode		= [NSMutableArray new];
 	NSMutableArray * deleteWay		= [NSMutableArray new];
 	NSMutableArray * deleteRelation	= [NSMutableArray new];
@@ -2341,7 +2341,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 				[deleteWay addObject:object];
 		} else if ( object.isRelation ) {
 			if ( insert.boolValue )
-				[insertRelation addObject:object];
+				[insertRelation addObject:object.isRelation];
 			else
 				[deleteRelation addObject:object];
 		} else {


### PR DESCRIPTION
This branch improves the interface of `Database` by adding type-hints to the collections, which makes it easier for both Objective-C and Swift to work with them.

In addition, it makes the code much easier to understand, since types don't need to be guessed anymore.