### PR TITLE
Refactoring: Improve interface of `EditorMapLayer`

### DIFF
--- a/src/Shared/EditorMapLayer.h
+++ b/src/Shared/EditorMapLayer.h
@@ -34,8 +34,6 @@ extern const double MinIconSizeInPixels;
 	CGSize					_iconSize;
 	double					_highwayScale;
 
-	NSMutableSet		*	_nameDrawSet;
-
 	NSMutableArray<OsmBaseObject *>		*	_shownObjects;
 	NSMutableSet<OsmBaseObject *>		*	_fadingOutSet;
 

--- a/src/Shared/EditorMapLayer.h
+++ b/src/Shared/EditorMapLayer.h
@@ -73,7 +73,7 @@ extern const double MinIconSizeInPixels;
 - (id)initWithMapView:(MapView *)mapView;
 - (void)didReceiveMemoryWarning;
 
-- (OsmBaseObject *)osmHitTest:(CGPoint)point radius:(CGFloat)radius testNodes:(BOOL)testNodes ignoreList:(NSArray *)ignoreList segment:(NSInteger *)segment;
+- (OsmBaseObject *)osmHitTest:(CGPoint)point radius:(CGFloat)radius testNodes:(BOOL)testNodes ignoreList:(NSArray<OsmBaseObject *> *)ignoreList segment:(NSInteger *)segment;
 - (NSArray *)osmHitTestMultiple:(CGPoint)point radius:(CGFloat)radius ;
 - (OsmNode *)osmHitTestNodeInSelectedWay:(CGPoint)point radius:(CGFloat)radius ;
 

--- a/src/Shared/EditorMapLayer.h
+++ b/src/Shared/EditorMapLayer.h
@@ -36,8 +36,8 @@ extern const double MinIconSizeInPixels;
 
 	NSMutableSet		*	_nameDrawSet;
 
-	NSMutableArray		*	_shownObjects;
-	NSMutableSet		*	_fadingOutSet;
+	NSMutableArray<OsmBaseObject *>		*	_shownObjects;
+	NSMutableSet<OsmBaseObject *>		*	_fadingOutSet;
 
 	NSMutableArray		*	_highlightLayers;
 

--- a/src/Shared/EditorMapLayer.h
+++ b/src/Shared/EditorMapLayer.h
@@ -74,7 +74,7 @@ extern const double MinIconSizeInPixels;
 - (void)didReceiveMemoryWarning;
 
 - (OsmBaseObject *)osmHitTest:(CGPoint)point radius:(CGFloat)radius testNodes:(BOOL)testNodes ignoreList:(NSArray<OsmBaseObject *> *)ignoreList segment:(NSInteger *)segment;
-- (NSArray *)osmHitTestMultiple:(CGPoint)point radius:(CGFloat)radius ;
+- (NSArray<OsmBaseObject *> *)osmHitTestMultiple:(CGPoint)point radius:(CGFloat)radius ;
 - (OsmNode *)osmHitTestNodeInSelectedWay:(CGPoint)point radius:(CGFloat)radius ;
 
 - (void)updateMapLocation;

--- a/src/Shared/EditorMapLayer.h
+++ b/src/Shared/EditorMapLayer.h
@@ -37,7 +37,7 @@ extern const double MinIconSizeInPixels;
 	NSMutableArray<OsmBaseObject *>		*	_shownObjects;
 	NSMutableSet<OsmBaseObject *>		*	_fadingOutSet;
 
-	NSMutableArray		*	_highlightLayers;
+	NSMutableArray<CALayer *>		*	_highlightLayers;
 
 	BOOL					_isPerformingLayout;
 

--- a/src/Shared/EditorMapLayer.m
+++ b/src/Shared/EditorMapLayer.m
@@ -723,13 +723,12 @@ static NSInteger ClipLineToRect( OSMPoint p1, OSMPoint p2, OSMRect rect, OSMPoin
 	}
 }
 
--(CAShapeLayer *)getOceanLayer:(NSArray *)objectList
+-(CAShapeLayer *)getOceanLayer:(NSArray<OsmBaseObject *> *)objectList
 {
 	// get all coastline ways
 	NSMutableArray * outerSegments = [NSMutableArray new];
 	NSMutableArray * innerSegments = [NSMutableArray new];
-	for ( id obj in objectList ) {
-		OsmBaseObject * object = obj;
+	for ( OsmBaseObject * object in objectList ) {
 		if ( object.isWay.isClosed && [object.tags[@"natural"] isEqualToString:@"water"] ) {
 			continue;	// lakes are not a concern of this function
 		}
@@ -2237,7 +2236,7 @@ static BOOL VisibleSizeLessStrict( OsmBaseObject * obj1, OsmBaseObject * obj2 )
 #endif
 }
 
-- (NSMutableArray *)getObjectsToDisplay
+- (NSMutableArray<OsmBaseObject *> *)getObjectsToDisplay
 {
 #if TARGET_OS_IPHONE
 	double geekScore = [self.geekbenchScoreProvider geekbenchScore];
@@ -2355,13 +2354,13 @@ static BOOL VisibleSizeLessStrict( OsmBaseObject * obj1, OsmBaseObject * obj2 )
 		_baseLayer.sublayerTransform	= CATransform3DIdentity;
 	}
 
-	NSArray * previousObjects = _shownObjects;
+	NSArray<OsmBaseObject *> * previousObjects = _shownObjects;
 
 	_shownObjects = [self getObjectsToDisplay];
 	[_shownObjects addObjectsFromArray:_fadingOutSet.allObjects];
 
 	// remove layers no longer visible
-	NSMutableSet * removals = [NSMutableSet setWithArray:previousObjects];
+	NSMutableSet<OsmBaseObject *> * removals = [NSMutableSet setWithArray:previousObjects];
 	for ( OsmBaseObject * object in _shownObjects ) {
 		[removals removeObject:object];
 	}
@@ -2603,7 +2602,7 @@ inline static CGFloat HitTestLineSegment(CLLocationCoordinate2D point, OSMSize m
 }
 
 // distance is in units of the hit test radius (WayHitTestRadius)
-+ (void)osmHitTestEnumerate:(CGPoint)point radius:(CGFloat)radius mapView:(MapView *)mapView objects:(NSArray *)objects testNodes:(BOOL)testNodes
++ (void)osmHitTestEnumerate:(CGPoint)point radius:(CGFloat)radius mapView:(MapView *)mapView objects:(NSArray<OsmBaseObject *> *)objects testNodes:(BOOL)testNodes
 				 ignoreList:(NSArray *)ignoreList block:(void(^)(OsmBaseObject * obj,CGFloat dist,NSInteger segment))block
 {
 	CLLocationCoordinate2D location = [mapView longitudeLatitudeForScreenPoint:point birdsEye:YES];

--- a/src/Shared/EditorMapLayer.m
+++ b/src/Shared/EditorMapLayer.m
@@ -2603,7 +2603,7 @@ inline static CGFloat HitTestLineSegment(CLLocationCoordinate2D point, OSMSize m
 
 // distance is in units of the hit test radius (WayHitTestRadius)
 + (void)osmHitTestEnumerate:(CGPoint)point radius:(CGFloat)radius mapView:(MapView *)mapView objects:(NSArray<OsmBaseObject *> *)objects testNodes:(BOOL)testNodes
-				 ignoreList:(NSArray *)ignoreList block:(void(^)(OsmBaseObject * obj,CGFloat dist,NSInteger segment))block
+				 ignoreList:(NSArray<OsmBaseObject *> *)ignoreList block:(void(^)(OsmBaseObject * obj,CGFloat dist,NSInteger segment))block
 {
 	CLLocationCoordinate2D location = [mapView longitudeLatitudeForScreenPoint:point birdsEye:YES];
 	OSMRect viewCoord = [mapView screenLongitudeLatitude];
@@ -2680,7 +2680,7 @@ inline static CGFloat HitTestLineSegment(CLLocationCoordinate2D point, OSMSize m
 }
 
 // default hit test when clicking on the map, or drag-connecting
-- (OsmBaseObject *)osmHitTest:(CGPoint)point radius:(CGFloat)radius testNodes:(BOOL)testNodes ignoreList:(NSArray *)ignoreList segment:(NSInteger *)pSegment
+- (OsmBaseObject *)osmHitTest:(CGPoint)point radius:(CGFloat)radius testNodes:(BOOL)testNodes ignoreList:(NSArray<OsmBaseObject *> *)ignoreList segment:(NSInteger *)pSegment
 {
 	if ( self.hidden )
 		return nil;

--- a/src/Shared/EditorMapLayer.m
+++ b/src/Shared/EditorMapLayer.m
@@ -1723,7 +1723,7 @@ const static CGFloat Z_ARROWS			= Z_BASE + 11 * ZSCALE;
     return degrees * M_PI / 180;
 }
 
--(NSMutableArray *)getShapeLayersForHighlights
+-(NSMutableArray<CALayer *> *)getShapeLayersForHighlights
 {
 	double				geekScore	= [self.geekbenchScoreProvider geekbenchScore];
 	NSInteger			nameLimit	= 5 + (geekScore - 500) / 200;	// 500 -> 5, 2500 -> 10

--- a/src/Shared/EditorMapLayer.m
+++ b/src/Shared/EditorMapLayer.m
@@ -2729,13 +2729,13 @@ inline static CGFloat HitTestLineSegment(CLLocationCoordinate2D point, OSMSize m
 }
 
 // return all nearby objects
-- (NSArray *)osmHitTestMultiple:(CGPoint)point radius:(CGFloat)radius
+- (NSArray<OsmBaseObject *> *)osmHitTestMultiple:(CGPoint)point radius:(CGFloat)radius
 {
-	NSMutableSet * objectSet = [NSMutableSet new];
+	NSMutableSet<OsmBaseObject *> * objectSet = [NSMutableSet new];
 	[EditorMapLayer osmHitTestEnumerate:point radius:radius mapView:self.mapView objects:_shownObjects testNodes:YES ignoreList:nil block:^(OsmBaseObject *obj, CGFloat dist, NSInteger segment) {
 		[objectSet addObject:obj];
 	}];
-	NSMutableArray * objectList = [objectSet.allObjects mutableCopy];
+	NSMutableArray<OsmBaseObject *> * objectList = [objectSet.allObjects mutableCopy];
 	[objectList sortUsingComparator:^NSComparisonResult(OsmBaseObject * o1, OsmBaseObject * o2) {
 		int diff = (o1.isRelation?2:o1.isWay?1:0) - (o2.isRelation?2:o2.isWay?1:0);
 		if ( diff )

--- a/src/Shared/MapView.m
+++ b/src/Shared/MapView.m
@@ -3456,13 +3456,13 @@ static NSString * const DisplayLinkPanning	= @"Panning";
 	if ( longPress.state == UIGestureRecognizerStateBegan && !_editorLayer.hidden ) {
 		CGPoint point = [longPress locationInView:self];
 
-		NSArray * objects = [self.editorLayer osmHitTestMultiple:point radius:DefaultHitTestRadius];
+		NSArray<OsmBaseObject *> * objects = [self.editorLayer osmHitTestMultiple:point radius:DefaultHitTestRadius];
 		if ( objects.count == 0 )
 			return;
 
 		// special case for adding members to relations:
 		if ( _editorLayer.selectedPrimary.isRelation.isMultipolygon ) {
-			NSArray * ways = [objects filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(OsmBaseObject * obj, id bindings) {
+			NSArray<OsmBaseObject *> * ways = [objects filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(OsmBaseObject * obj, id bindings) {
 				return obj.isWay != nil;
 			}]];
 			if ( ways.count == 1 ) {

--- a/src/Shared/MapView.m
+++ b/src/Shared/MapView.m
@@ -2559,7 +2559,7 @@ NSString * ActionTitle( EDIT_ACTION action, BOOL abbrev )
 		return nil;
 #endif
 
-	NSArray * ignoreList = nil;
+	NSArray<OsmBaseObject *> * ignoreList = nil;
 	NSInteger index = [way.nodes indexOfObject:node];
 	NSArray * parentWays = node.wayCount == 1 ? @[ way ] : [_editorLayer.mapData waysContainingNode:node];
 	if ( way.nodes.count < 3 ) {


### PR DESCRIPTION
This branch improves the interface of `EditorMapLayer` by adding type-hints to the collections, which makes it easier for both Objective-C and Swift to work with them.

In addition, it makes the code much easier to understand, since types don't need to be guessed anymore.