### PR TITLE
Refactoring: Split `OsmMapData` into several files

### DIFF
--- a/src/Shared/OsmMapData.h
+++ b/src/Shared/OsmMapData.h
@@ -36,18 +36,6 @@ typedef void 		(^EditActionWithNode)(OsmNode * node);
 typedef OsmWay    * (^EditActionReturnWay)(void);
 typedef OsmNode   * (^EditActionReturnNode)(void);
 
-
-
-@interface OsmUserStatistics : NSObject
-@property (strong,nonatomic)	NSString	*	user;
-@property (strong,nonatomic)	NSDate		*	lastEdit;
-@property (assign,nonatomic)	NSInteger		editCount;
-@property (strong,nonatomic)	NSMutableSet *	changeSets;
-@property (assign,nonatomic)	NSInteger		changeSetsCount;
-@end
-
-
-
 @interface OsmMapData : NSObject <NSXMLParserDelegate, NSCoding, NSKeyedArchiverDelegate, NSKeyedUnarchiverDelegate>
 {
 	NSString			*	_parserCurrentElementText;

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -26,19 +26,11 @@
 
 #import "Database.h"
 #import "EditorMapLayer.h"
+#import "OsmUserStatistics.h"
 
 #define OSM_SERVER_KEY	@"OSM Server"
 
 NSString * OSM_API_URL;
-
-@implementation OsmUserStatistics
-@synthesize changeSetsCount = _changeSetsCount;
--(id)copyWithZone:(NSZone *)zone
-{
-	return self;
-}
-@end
-
 
 @interface ServerQuery : NSObject
 @property (strong,nonatomic)	NSMutableArray *	quadList;

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -27,18 +27,11 @@
 #import "Database.h"
 #import "EditorMapLayer.h"
 #import "OsmUserStatistics.h"
+#import "ServerQuery.h"
 
 #define OSM_SERVER_KEY	@"OSM Server"
 
 NSString * OSM_API_URL;
-
-@interface ServerQuery : NSObject
-@property (strong,nonatomic)	NSMutableArray *	quadList;
-@property (assign,nonatomic)	OSMRect				rect;
-@end
-@implementation ServerQuery
-@end
-
 
 #pragma mark OsmMapData
 

--- a/src/Shared/OsmUserStatistics.h
+++ b/src/Shared/OsmUserStatistics.h
@@ -1,0 +1,17 @@
+//
+//  OsmUserStatistics.h
+//  Go Map!!
+//
+//  Created by Wolfgang Timme on 3/1/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface OsmUserStatistics : NSObject
+@property (strong,nonatomic)    NSString    *    user;
+@property (strong,nonatomic)    NSDate        *    lastEdit;
+@property (assign,nonatomic)    NSInteger        editCount;
+@property (strong,nonatomic)    NSMutableSet *    changeSets;
+@property (assign,nonatomic)    NSInteger        changeSetsCount;
+@end

--- a/src/Shared/OsmUserStatistics.m
+++ b/src/Shared/OsmUserStatistics.m
@@ -1,0 +1,17 @@
+//
+//  OsmUserStatistics.m
+//  Go Map!!
+//
+//  Created by Wolfgang Timme on 3/1/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+#import "OsmUserStatistics.h"
+
+@implementation OsmUserStatistics
+@synthesize changeSetsCount = _changeSetsCount;
+-(id)copyWithZone:(NSZone *)zone
+{
+    return self;
+}
+@end

--- a/src/Shared/ServerQuery.h
+++ b/src/Shared/ServerQuery.h
@@ -1,0 +1,14 @@
+//
+//  ServerQuery.h
+//  Go Map!!
+//
+//  Created by Wolfgang Timme on 3/1/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface ServerQuery : NSObject
+@property (strong,nonatomic)    NSMutableArray *    quadList;
+@property (assign,nonatomic)    OSMRect                rect;
+@end

--- a/src/Shared/ServerQuery.m
+++ b/src/Shared/ServerQuery.m
@@ -1,0 +1,13 @@
+//
+//  ServerQuery.m
+//  Go Map!!
+//
+//  Created by Wolfgang Timme on 3/1/20.
+//  Copyright © 2020 Bryce. All rights reserved.
+//
+
+#import "ServerQuery.h"
+
+@implementation ServerQuery
+
+@end

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -523,6 +523,7 @@
 		64E21EB322651620004605D7 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E21EB222651620004605D7 /* LoginViewController.swift */; };
 		64E21EB522651C06004605D7 /* OSMMapDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E21EB422651C06004605D7 /* OSMMapDataTestCase.swift */; };
 		64E21EB822651F2D004605D7 /* XCTestCase+UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E21EB722651F2D004605D7 /* XCTestCase+UserDefaults.swift */; };
+		64F59A5E240BA18A0093DCDB /* OsmUserStatistics.m in Sources */ = {isa = PBXBuildFile; fileRef = 64F59A5D240BA18A0093DCDB /* OsmUserStatistics.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1162,6 +1163,8 @@
 		64E21EB222651620004605D7 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		64E21EB422651C06004605D7 /* OSMMapDataTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSMMapDataTestCase.swift; sourceTree = "<group>"; };
 		64E21EB722651F2D004605D7 /* XCTestCase+UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+UserDefaults.swift"; sourceTree = "<group>"; };
+		64F59A5C240BA18A0093DCDB /* OsmUserStatistics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OsmUserStatistics.h; path = ../Shared/OsmUserStatistics.h; sourceTree = "<group>"; };
+		64F59A5D240BA18A0093DCDB /* OsmUserStatistics.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OsmUserStatistics.m; path = ../Shared/OsmUserStatistics.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1900,6 +1903,8 @@
 				021BFCE91BDF3F9E00CE255A /* VoiceAnnouncement.m */,
 				6453777423D3959500656A1C /* IsOsmBooleanFalse.h */,
 				6453777523D3959500656A1C /* IsOsmBooleanFalse.m */,
+				64F59A5C240BA18A0093DCDB /* OsmUserStatistics.h */,
+				64F59A5D240BA18A0093DCDB /* OsmUserStatistics.m */,
 			);
 			name = Shared;
 			sourceTree = "<group>";
@@ -2627,6 +2632,7 @@
 				028E0C0C20B2182100CEC71F /* FilterObjectsViewController.m in Sources */,
 				0259E4081BCAEC88006C354C /* MyApplication.m in Sources */,
 				022ABCA120C1AACF002D4977 /* MultilineTableViewCell.m in Sources */,
+				64F59A5E240BA18A0093DCDB /* OsmUserStatistics.m in Sources */,
 				02F371B416A4F3E6003E9548 /* HelpViewController.m in Sources */,
 				02FFCE0B16A7360B001A5B8A /* NSMutableArray+PartialSort.mm in Sources */,
 				027EDC73206F3EED00D349D6 /* DDXMLDocument.m in Sources */,

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -524,6 +524,7 @@
 		64E21EB522651C06004605D7 /* OSMMapDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E21EB422651C06004605D7 /* OSMMapDataTestCase.swift */; };
 		64E21EB822651F2D004605D7 /* XCTestCase+UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E21EB722651F2D004605D7 /* XCTestCase+UserDefaults.swift */; };
 		64F59A5E240BA18A0093DCDB /* OsmUserStatistics.m in Sources */ = {isa = PBXBuildFile; fileRef = 64F59A5D240BA18A0093DCDB /* OsmUserStatistics.m */; };
+		64F59A64240BA27C0093DCDB /* ServerQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 64F59A63240BA27B0093DCDB /* ServerQuery.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1165,6 +1166,8 @@
 		64E21EB722651F2D004605D7 /* XCTestCase+UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+UserDefaults.swift"; sourceTree = "<group>"; };
 		64F59A5C240BA18A0093DCDB /* OsmUserStatistics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OsmUserStatistics.h; path = ../Shared/OsmUserStatistics.h; sourceTree = "<group>"; };
 		64F59A5D240BA18A0093DCDB /* OsmUserStatistics.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = OsmUserStatistics.m; path = ../Shared/OsmUserStatistics.m; sourceTree = "<group>"; };
+		64F59A62240BA27B0093DCDB /* ServerQuery.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ServerQuery.h; path = ../Shared/ServerQuery.h; sourceTree = "<group>"; };
+		64F59A63240BA27B0093DCDB /* ServerQuery.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = ServerQuery.m; path = ../Shared/ServerQuery.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1905,6 +1908,8 @@
 				6453777523D3959500656A1C /* IsOsmBooleanFalse.m */,
 				64F59A5C240BA18A0093DCDB /* OsmUserStatistics.h */,
 				64F59A5D240BA18A0093DCDB /* OsmUserStatistics.m */,
+				64F59A62240BA27B0093DCDB /* ServerQuery.h */,
+				64F59A63240BA27B0093DCDB /* ServerQuery.m */,
 			);
 			name = Shared;
 			sourceTree = "<group>";
@@ -2605,6 +2610,7 @@
 				64348D01225E8D3F00ADE7FB /* OsmNode+Direction.swift in Sources */,
 				0230558B19B931B20041B151 /* CustomPresetController.m in Sources */,
 				021C6AA81686145C00FB17B0 /* UndoManager.m in Sources */,
+				64F59A64240BA27C0093DCDB /* ServerQuery.m in Sources */,
 				02E8436519B39FAD0044AC1D /* OsmNotesDatabase.m in Sources */,
 				023D1723168A36B10011FABC /* POIAttributesViewController.m in Sources */,
 				022B09A719BD3F7B0041687B /* QuadMapC.mm in Sources */,

--- a/src/iOS/NearbyMappersViewController.m
+++ b/src/iOS/NearbyMappersViewController.m
@@ -12,7 +12,7 @@
 #import "MapView.h"
 #import "NearbyMappersViewController.h"
 #import "WebPageViewController.h"
-
+#import "OsmUserStatistics.h"
 
 @implementation NearbyMappersViewController
 


### PR DESCRIPTION
This branch moves the classes `OsmUserStatistics` and `ServerQuery` from `OsmMapData` to dedicated files.

The goal of this pull request to improve the readability of `OsmMapData.{h,m}` and making it easier to maintain.