### PR TITLE
Refactoring: Add type hinting to `OsmMapData`

### DIFF
--- a/src/Shared/MapView.m
+++ b/src/Shared/MapView.m
@@ -2148,7 +2148,7 @@ NSString * ActionTitle( EDIT_ACTION action, BOOL abbrev )
 	if ( _editorLayer.selectedWay ) {
 		if ( _editorLayer.selectedNode ) {
 			// node in way
-			NSArray * parentWays = [_editorLayer.mapData waysContainingNode:_editorLayer.selectedNode];
+			NSArray<OsmWay *> * parentWays = [_editorLayer.mapData waysContainingNode:_editorLayer.selectedNode];
             BOOL disconnect		= parentWays.count > 1 || _editorLayer.selectedNode.hasInterestingTags;
 			BOOL split 			= _editorLayer.selectedWay.isClosed || (_editorLayer.selectedNode != _editorLayer.selectedWay.nodes[0] && _editorLayer.selectedNode != _editorLayer.selectedWay.nodes.lastObject);
 			BOOL join 			= parentWays.count > 1;
@@ -2561,7 +2561,7 @@ NSString * ActionTitle( EDIT_ACTION action, BOOL abbrev )
 
 	NSArray<OsmBaseObject *> * ignoreList = nil;
 	NSInteger index = [way.nodes indexOfObject:node];
-	NSArray * parentWays = node.wayCount == 1 ? @[ way ] : [_editorLayer.mapData waysContainingNode:node];
+	NSArray<OsmWay *> * parentWays = node.wayCount == 1 ? @[ way ] : [_editorLayer.mapData waysContainingNode:node];
 	if ( way.nodes.count < 3 ) {
 		ignoreList = [parentWays arrayByAddingObjectsFromArray:way.nodes];
 	} else if ( index == 0 ) {

--- a/src/Shared/OsmMapData+Edit.m
+++ b/src/Shared/OsmMapData+Edit.m
@@ -314,7 +314,7 @@
 
 	// gather restrictions for parent ways
 	for ( OsmNode * node in nodes ) {
-		NSArray * parents = [self waysContainingNode:node];
+		NSArray<OsmWay *> * parents = [self waysContainingNode:node];
 		for ( OsmWay * parent in parents ) {
 			for ( OsmRelation * relation in parent.parentRelations ) {
 				if ( relation.isRestriction ) {
@@ -1065,7 +1065,7 @@ static NSInteger splitArea(NSArray * nodes, NSInteger idxA)
 		return nil;	// must be endpoint node
 	}
 
-	NSArray * ways = [self waysContainingNode:selectedNode];
+	NSArray<OsmWay *> * ways = [self waysContainingNode:selectedNode];
 	OsmWay * otherWay = nil;
 	for ( OsmWay * way in ways ) {
 		if ( way == selectedWay )

--- a/src/Shared/OsmMapData.h
+++ b/src/Shared/OsmMapData.h
@@ -133,7 +133,7 @@ typedef OsmNode   * (^EditActionReturnNode)(void);
 -(NSMutableSet *)tagValuesForKey:(NSString *)key;
 
 // editing
-+(NSSet *)tagsToAutomaticallyStrip;
++(NSSet<NSString *> *)tagsToAutomaticallyStrip;
 -(OsmNode *)createNodeAtLocation:(CLLocationCoordinate2D)loc;
 -(OsmWay *)createWay;
 -(OsmRelation *)createRelation;

--- a/src/Shared/OsmMapData.h
+++ b/src/Shared/OsmMapData.h
@@ -55,7 +55,7 @@ typedef OsmNode   * (^EditActionReturnNode)(void);
 	NSError				*	_parseError;
 	NSMutableDictionary	*	_nodes;
 	NSMutableDictionary	*	_ways;
-	NSMutableDictionary	*	_relations;
+	NSMutableDictionary<NSNumber *, OsmRelation *>	*	_relations;
 	QuadMap				*	_region;	// currently downloaded region
 	QuadMap				*	_spatial;	// spatial index of osm data
 	UndoManager			*	_undoManager;

--- a/src/Shared/OsmMapData.h
+++ b/src/Shared/OsmMapData.h
@@ -54,7 +54,7 @@ typedef OsmNode   * (^EditActionReturnNode)(void);
 	NSMutableArray		*	_parserStack;
 	NSError				*	_parseError;
 	NSMutableDictionary	*	_nodes;
-	NSMutableDictionary	*	_ways;
+	NSMutableDictionary<NSNumber *, OsmWay *>	*	_ways;
 	NSMutableDictionary<NSNumber *, OsmRelation *>	*	_relations;
 	QuadMap				*	_region;	// currently downloaded region
 	QuadMap				*	_spatial;	// spatial index of osm data

--- a/src/Shared/OsmMapData.h
+++ b/src/Shared/OsmMapData.h
@@ -117,7 +117,7 @@ typedef OsmNode   * (^EditActionReturnNode)(void);
 -(int32_t)nodeCount;
 -(int32_t)relationCount;
 
--(NSArray *)waysContainingNode:(OsmNode *)node;
+-(NSArray<OsmWay *> *)waysContainingNode:(OsmNode *)node;
 -(NSArray *)objectsContainingObject:(OsmBaseObject *)object;
 
 -(OsmNode *)nodeForRef:(NSNumber *)ref;

--- a/src/Shared/OsmMapData.h
+++ b/src/Shared/OsmMapData.h
@@ -24,7 +24,7 @@
 @class QuadBox;
 @class QuadMap;
 @class QuadMapC;
-
+@class OsmUserStatistics;
 
 BOOL IsOsmBooleanFalse( NSString * value );
 
@@ -157,7 +157,7 @@ typedef OsmNode   * (^EditActionReturnNode)(void);
 - (void)putRequest:(NSString *)url method:(NSString *)method xml:(NSXMLDocument *)xml completion:(void(^)(NSData * data,NSString * error))completion;
 +(NSString *)encodeBase64:(NSString *)plainText;
 
--(NSArray *)userStatisticsForRegion:(OSMRect)rect;
+-(NSArray<OsmUserStatistics *> *)userStatisticsForRegion:(OSMRect)rect;
 -(OSMRect)rootRect;
 
 @end

--- a/src/Shared/OsmMapData.h
+++ b/src/Shared/OsmMapData.h
@@ -53,7 +53,7 @@ typedef OsmNode   * (^EditActionReturnNode)(void);
 	NSString			*	_parserCurrentElementText;
 	NSMutableArray		*	_parserStack;
 	NSError				*	_parseError;
-	NSMutableDictionary	*	_nodes;
+	NSMutableDictionary<NSNumber *, OsmNode *>	*	_nodes;
 	NSMutableDictionary<NSNumber *, OsmWay *>	*	_ways;
 	NSMutableDictionary<NSNumber *, OsmRelation *>	*	_relations;
 	QuadMap				*	_region;	// currently downloaded region

--- a/src/Shared/OsmMapData.h
+++ b/src/Shared/OsmMapData.h
@@ -140,7 +140,7 @@ typedef OsmNode   * (^EditActionReturnNode)(void);
 
 
 -(void)setLongitude:(double)longitude latitude:(double)latitude forNode:(OsmNode *)node;
--(void)setTags:(NSDictionary *)dict forObject:(OsmBaseObject *)object;
+-(void)setTags:(NSDictionary<NSString *, NSString *> *)dict forObject:(OsmBaseObject *)object;
 -(void)registerUndoWithTarget:(id)target selector:(SEL)selector objects:(NSArray *)objects;
 
 

--- a/src/Shared/OsmMapData.h
+++ b/src/Shared/OsmMapData.h
@@ -130,7 +130,7 @@ typedef OsmNode   * (^EditActionReturnNode)(void);
 
 - (void)clearCachedProperties;
 
--(NSMutableSet *)tagValuesForKey:(NSString *)key;
+-(NSMutableSet<NSString *> *)tagValuesForKey:(NSString *)key;
 
 // editing
 +(NSSet<NSString *> *)tagsToAutomaticallyStrip;

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -249,9 +249,9 @@ static EditorMapLayer * g_EditorMapLayerForArchive = nil;
 	}
 }
 
--(NSArray *)waysContainingNode:(OsmNode *)node
+-(NSArray<OsmWay *> *)waysContainingNode:(OsmNode *)node
 {
-	__block NSMutableArray * a = [NSMutableArray new];
+	__block NSMutableArray<OsmWay *> * a = [NSMutableArray new];
 	[_ways enumerateKeysAndObjectsUsingBlock:^(NSNumber * ident, OsmWay * w, BOOL *stop) {
 		if ( [w.nodes containsObject:node] )
 			[a addObject:w];

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -178,10 +178,10 @@ static EditorMapLayer * g_EditorMapLayerForArchive = nil;
 }
 
 
-+(NSSet *)tagsToAutomaticallyStrip
++(NSSet<NSString *> *)tagsToAutomaticallyStrip
 {
 	static dispatch_once_t onceToken;
-	static NSSet * s_ignoreSet = nil;
+	static NSSet<NSString *> * s_ignoreSet = nil;
 	dispatch_once(&onceToken, ^{
 		s_ignoreSet = [NSSet setWithObjects:
 				@"tiger:upload_uuid", @"tiger:tlid", @"tiger:source", @"tiger:separated",

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -436,7 +436,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 	return newDict;
 }
 
--(void)setTags:(NSDictionary *)dict forObject:(OsmBaseObject *)object
+-(void)setTags:(NSDictionary<NSString *, NSString *> *)dict forObject:(OsmBaseObject *)object
 {
 	dict = DictWithTagsTruncatedTo255( dict );
 

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -281,7 +281,7 @@ static EditorMapLayer * g_EditorMapLayerForArchive = nil;
 	[_nodes enumerateKeysAndObjectsUsingBlock:^(NSString * ident,OsmNode * node,BOOL * stop){
 		block( node );
 	}];
-	[_ways enumerateKeysAndObjectsUsingBlock:^(NSString * ident,OsmWay * way,BOOL * stop) {
+	[_ways enumerateKeysAndObjectsUsingBlock:^(NSNumber * ident,OsmWay * way,BOOL * stop) {
 		block( way );
 	}];
 	[_relations enumerateKeysAndObjectsUsingBlock:^(NSNumber * ident,OsmRelation * relation,BOOL * stop){
@@ -314,7 +314,7 @@ static EditorMapLayer * g_EditorMapLayerForArchive = nil;
 			[set addObject:value];
 		}
 	}];
-	[_ways enumerateKeysAndObjectsUsingBlock:^(NSString * ident, OsmBaseObject * object, BOOL *stop) {
+	[_ways enumerateKeysAndObjectsUsingBlock:^(NSNumber * ident, OsmBaseObject * object, BOOL *stop) {
 		NSString * value = [object.tags objectForKey:key];
 		if ( value ) {
 			[set addObject:value];
@@ -329,7 +329,7 @@ static EditorMapLayer * g_EditorMapLayerForArchive = nil;
 
 	// special case for street names
 	if ( [key isEqualToString:@"addr:street"] ) {
-		[_ways enumerateKeysAndObjectsUsingBlock:^(NSString * ident, OsmBaseObject * object, BOOL *stop) {
+		[_ways enumerateKeysAndObjectsUsingBlock:^(NSNumber * ident, OsmBaseObject * object, BOOL *stop) {
 			NSString * value = [object.tags objectForKey:@"highway"];
 			if ( value ) {
 				value = [object.tags objectForKey:@"name"];
@@ -2050,7 +2050,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 			if ( object.isNode ) {
 				[_nodes setObject:object forKey:object.ident];
 			} else if ( object.isWay ) {
-				[_ways setObject:object forKey:object.ident];
+				[_ways setObject:object.isWay forKey:object.ident];
 			} else if ( object.isRelation ) {
 				[_relations setObject:object.isRelation forKey:object.ident];
 			} else {

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -284,8 +284,8 @@ static EditorMapLayer * g_EditorMapLayerForArchive = nil;
 	[_ways enumerateKeysAndObjectsUsingBlock:^(NSString * ident,OsmWay * way,BOOL * stop) {
 		block( way );
 	}];
-	[_relations enumerateKeysAndObjectsUsingBlock:^(NSString * ident,OsmNode * node,BOOL * stop){
-		block( node );
+	[_relations enumerateKeysAndObjectsUsingBlock:^(NSNumber * ident,OsmRelation * relation,BOOL * stop){
+		block( relation );
 	}];
 }
 - (void)enumerateObjectsInRegion:(OSMRect)bbox block:(void (^)(OsmBaseObject * obj))block
@@ -320,7 +320,7 @@ static EditorMapLayer * g_EditorMapLayerForArchive = nil;
 			[set addObject:value];
 		}
 	}];
-	[_relations enumerateKeysAndObjectsUsingBlock:^(NSString * ident, OsmBaseObject * object, BOOL *stop) {
+	[_relations enumerateKeysAndObjectsUsingBlock:^(NSNumber * ident, OsmBaseObject * object, BOOL *stop) {
 		NSString * value = [object.tags objectForKey:key];
 		if ( value ) {
 			[set addObject:value];
@@ -2052,7 +2052,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 			} else if ( object.isWay ) {
 				[_ways setObject:object forKey:object.ident];
 			} else if ( object.isRelation ) {
-				[_relations setObject:object forKey:object.ident];
+				[_relations setObject:object.isRelation forKey:object.ident];
 			} else {
 				assert(NO);
 			}

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -278,7 +278,7 @@ static EditorMapLayer * g_EditorMapLayerForArchive = nil;
 
 - (void)enumerateObjectsUsingBlock:(void (^)(OsmBaseObject * obj))block
 {
-	[_nodes enumerateKeysAndObjectsUsingBlock:^(NSString * ident,OsmNode * node,BOOL * stop){
+	[_nodes enumerateKeysAndObjectsUsingBlock:^(NSNumber * ident,OsmNode * node,BOOL * stop){
 		block( node );
 	}];
 	[_ways enumerateKeysAndObjectsUsingBlock:^(NSNumber * ident,OsmWay * way,BOOL * stop) {
@@ -308,7 +308,7 @@ static EditorMapLayer * g_EditorMapLayerForArchive = nil;
 -(NSMutableSet *)tagValuesForKey:(NSString *)key
 {
 	NSMutableSet * set = [NSMutableSet set];
-	[_nodes enumerateKeysAndObjectsUsingBlock:^(NSString * ident, OsmBaseObject * object, BOOL *stop) {
+	[_nodes enumerateKeysAndObjectsUsingBlock:^(NSNumber * ident, OsmBaseObject * object, BOOL *stop) {
 		NSString * value = [object.tags objectForKey:key];
 		if ( value ) {
 			[set addObject:value];
@@ -2048,7 +2048,7 @@ static NSDictionary * DictWithTagsTruncatedTo255( NSDictionary * tags )
 		if ( [object isKindOfClass:[OsmBaseObject class]] ) {
 
 			if ( object.isNode ) {
-				[_nodes setObject:object forKey:object.ident];
+				[_nodes setObject:object.isNode forKey:object.ident];
 			} else if ( object.isWay ) {
 				[_ways setObject:object.isWay forKey:object.ident];
 			} else if ( object.isRelation ) {

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -343,9 +343,9 @@ static EditorMapLayer * g_EditorMapLayerForArchive = nil;
 }
 
 
--(NSArray *)userStatisticsForRegion:(OSMRect)rect
+-(NSArray<OsmUserStatistics *> *)userStatisticsForRegion:(OSMRect)rect
 {
-	NSMutableDictionary * dict = [NSMutableDictionary dictionary];
+	NSMutableDictionary<NSString *, OsmUserStatistics *> * dict = [NSMutableDictionary dictionary];
 
 	[self enumerateObjectsInRegion:rect block:^(OsmBaseObject * base) {
 		NSDate * date = [base dateForTimestamp];

--- a/src/Shared/OsmMapData.m
+++ b/src/Shared/OsmMapData.m
@@ -305,9 +305,9 @@ static EditorMapLayer * g_EditorMapLayerForArchive = nil;
 }
 
 
--(NSMutableSet *)tagValuesForKey:(NSString *)key
+-(NSMutableSet<NSString *> *)tagValuesForKey:(NSString *)key
 {
-	NSMutableSet * set = [NSMutableSet set];
+	NSMutableSet<NSString *> * set = [NSMutableSet set];
 	[_nodes enumerateKeysAndObjectsUsingBlock:^(NSNumber * ident, OsmBaseObject * object, BOOL *stop) {
 		NSString * value = [object.tags objectForKey:key];
 		if ( value ) {

--- a/src/iOS/OSMModels/OsmBaseObject.h
+++ b/src/iOS/OSMModels/OsmBaseObject.h
@@ -95,7 +95,7 @@ NSDictionary * MergeTags(NSDictionary * myself, NSDictionary * tags, BOOL failOn
 
 -(void)incrementModifyCount:(UndoManager *)undo;
 -(void)resetModifyCount:(UndoManager *)undo;
--(void)setTags:(NSDictionary *)tags undo:(UndoManager *)undo;
+-(void)setTags:(NSDictionary<NSString *, NSString *> *)tags undo:(UndoManager *)undo;
 -(void)setTimestamp:(NSDate *)date undo:(UndoManager *)undo;
 -(void)setDeleted:(BOOL)deleted undo:(UndoManager *)undo;
 

--- a/src/iOS/OSMModels/OsmBaseObject.h
+++ b/src/iOS/OSMModels/OsmBaseObject.h
@@ -44,7 +44,7 @@ NSDictionary * MergeTags(NSDictionary * myself, NSDictionary * tags, BOOL failOn
 @protected
     int32_t                _modifyCount;
     BOOL                _constructed;
-    NSDictionary    *    _tags;
+    NSDictionary<NSString *, NSString *>    *    _tags;
     NSNumber        *    _ident;
     NSArray            *    _parentRelations;
 
@@ -65,7 +65,7 @@ NSDictionary * MergeTags(NSDictionary * myself, NSDictionary * tags, BOOL failOn
 
 
 // attributes
-@property (readonly,nonatomic)    NSDictionary    *    tags;
+@property (readonly,nonatomic)    NSDictionary<NSString *, NSString *>    *    tags;
 @property (readonly,nonatomic)    NSNumber        *    ident;
 @property (readonly,nonatomic)    NSString        *    user;
 @property (readonly,nonatomic)    NSString        *    timestamp;

--- a/src/iOS/OSMModels/OsmBaseObject.m
+++ b/src/iOS/OSMModels/OsmBaseObject.m
@@ -392,7 +392,7 @@ NSDictionary * MergeTags( NSDictionary * ourTags, NSDictionary * otherTags, BOOL
 {
     return _tags;
 }
--(void)setTags:(NSDictionary *)tags undo:(UndoManager *)undo
+-(void)setTags:(NSDictionary<NSString *, NSString *> *)tags undo:(UndoManager *)undo
 {
     if ( _constructed ) {
         assert(undo);

--- a/src/iOS/OSMModels/OsmBaseObject.m
+++ b/src/iOS/OSMModels/OsmBaseObject.m
@@ -388,7 +388,7 @@ NSDictionary * MergeTags( NSDictionary * ourTags, NSDictionary * otherTags, BOOL
     _deleted = deleted;
 }
 
--(NSDictionary *)tags
+-(NSDictionary<NSString *, NSString *> *)tags
 {
     return _tags;
 }

--- a/src/iOS/POIAllTagsViewController.m
+++ b/src/iOS/POIAllTagsViewController.m
@@ -298,7 +298,7 @@
 			NSString * key = kv[0];
 			NSSet * set = [CommonTagList allTagValuesForKey:key];
 			AppDelegate * appDelegate = [AppDelegate getAppDelegate];
-			NSMutableSet * values = [appDelegate.mapView.editorLayer.mapData tagValuesForKey:key];
+			NSMutableSet<NSString *> * values = [appDelegate.mapView.editorLayer.mapData tagValuesForKey:key];
 			[values addObjectsFromArray:[set allObjects]];
 			NSArray * list = [values allObjects];
 			[(AutocompleteTextField *)textField setCompletions:list];

--- a/src/iOS/POICommonTagsViewController.m
+++ b/src/iOS/POICommonTagsViewController.m
@@ -398,7 +398,7 @@
 			return;	// should never happen
 		NSSet * set = [CommonTagList allTagValuesForKey:key];
 		AppDelegate * appDelegate = [AppDelegate getAppDelegate];
-		NSMutableSet * values = [appDelegate.mapView.editorLayer.mapData tagValuesForKey:key];
+		NSMutableSet<NSString *> * values = [appDelegate.mapView.editorLayer.mapData tagValuesForKey:key];
 		[values addObjectsFromArray:[set allObjects]];
 		NSArray * list = [values allObjects];
 		[(AutocompleteTextField *)textField setCompletions:list];

--- a/src/iOS/TurnRestrictController.m
+++ b/src/iOS/TurnRestrictController.m
@@ -65,7 +65,7 @@
 
 	// get highways that contain selection
 	OsmMapData * mapData = [AppDelegate getAppDelegate].mapView.editorLayer.mapData;
-	NSArray * parentWays = [mapData waysContainingNode:_centralNode];
+	NSArray<OsmWay *> * parentWays = [mapData waysContainingNode:_centralNode];
 	parentWays = [parentWays filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(OsmWay * way, NSDictionary *bindings) {
 		return way.tags[@"highway"] != nil;
 	}]];


### PR DESCRIPTION
This branch adds type-hinting to the collections of `OsmMapData`'s public interface. It also follows up on the hints by adding them to the callers.

The goal of this pull request is to improve the interoperability with Swift, as well as to improve the readability of the code.