### PR TITLE
Bugfix: Fix blurry icons in "POI Type" screen

### DIFF
--- a/src/Maki Icons.xcassets/maki-aerialway.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-aerialway.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-airfield.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-airfield.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-airport.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-airport.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-alcohol-shop.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-alcohol-shop.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-american-football.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-american-football.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-amusement-park.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-amusement-park.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-aquarium.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-aquarium.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-art-gallery.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-art-gallery.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-attraction.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-attraction.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-bakery.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-bakery.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-bank-JP.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-bank-JP.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-bank.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-bank.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-bar.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-bar.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-barrier.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-barrier.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-baseball.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-baseball.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-basketball.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-basketball.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-bbq.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-bbq.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-beach.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-beach.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-beer.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-beer.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-bicycle-share.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-bicycle-share.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-bicycle.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-bicycle.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-blood-bank.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-blood-bank.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-bowling-alley.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-bowling-alley.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-bridge.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-bridge.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-building-alt1.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-building-alt1.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-building.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-building.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-bus.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-bus.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-cafe.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-cafe.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-campsite.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-campsite.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-car-rental.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-car-rental.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-car-repair.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-car-repair.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-car.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-car.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-casino.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-casino.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-castle-JP.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-castle-JP.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-castle.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-castle.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-cemetery-JP.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-cemetery-JP.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-cemetery.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-cemetery.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-charging-station.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-charging-station.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-cinema.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-cinema.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-circle-stroked.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-circle-stroked.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-circle.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-circle.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-city.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-city.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-clothing-store.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-clothing-store.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-college-JP.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-college-JP.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-college.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-college.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-commercial.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-commercial.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-communications-tower.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-communications-tower.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-confectionery.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-confectionery.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-convenience.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-convenience.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-cricket.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-cricket.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-cross.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-cross.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-dam.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-dam.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-danger.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-danger.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-defibrillator.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-defibrillator.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-dentist.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-dentist.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-doctor.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-doctor.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-dog-park.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-dog-park.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-drinking-water.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-drinking-water.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-embassy.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-embassy.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-emergency-phone.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-emergency-phone.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-entrance-alt1.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-entrance-alt1.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-entrance.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-entrance.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-farm.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-farm.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-fast-food.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-fast-food.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-fence.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-fence.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-ferry.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-ferry.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-fire-station-JP.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-fire-station-JP.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-fire-station.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-fire-station.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-fitness-centre.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-fitness-centre.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-florist.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-florist.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-fuel.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-fuel.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-furniture.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-furniture.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-gaming.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-gaming.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-garden-centre.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-garden-centre.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-garden.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-garden.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-gift.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-gift.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-globe.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-globe.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-golf.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-golf.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-grocery.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-grocery.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-hairdresser.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-hairdresser.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-harbor.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-harbor.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-hardware.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-hardware.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-heart.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-heart.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-heliport.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-heliport.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-home.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-home.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-horse-riding.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-horse-riding.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-hospital-JP.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-hospital-JP.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-hospital.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-hospital.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-ice-cream.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-ice-cream.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-industry.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-industry.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-information.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-information.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-jewelry-store.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-jewelry-store.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-karaoke.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-karaoke.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-landmark-JP.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-landmark-JP.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-landmark.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-landmark.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-landuse.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-landuse.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-laundry.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-laundry.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-library.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-library.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-lighthouse.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-lighthouse.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-lodging.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-lodging.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-logging.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-logging.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-marker-stroked.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-marker-stroked.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-marker.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-marker.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-mobile-phone.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-mobile-phone.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-monument.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-monument.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-mountain.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-mountain.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-museum.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-museum.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-music.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-music.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-natural.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-natural.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-optician.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-optician.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-paint.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-paint.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-park-alt1.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-park-alt1.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-park.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-park.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-parking-garage.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-parking-garage.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-parking.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-parking.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-pharmacy.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-pharmacy.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-picnic-site.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-picnic-site.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-pitch.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-pitch.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-place-of-worship.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-place-of-worship.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-playground.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-playground.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-police-JP.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-police-JP.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-police.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-police.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-post-JP.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-post-JP.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-post.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-post.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-prison.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-prison.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-rail-light.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-rail-light.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-rail-metro.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-rail-metro.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-rail.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-rail.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-ranger-station.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-ranger-station.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-recycling.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-recycling.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-religious-buddhist.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-religious-buddhist.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-religious-christian.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-religious-christian.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-religious-jewish.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-religious-jewish.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-religious-muslim.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-religious-muslim.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-religious-shinto.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-religious-shinto.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-residential-community.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-residential-community.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-restaurant-noodle.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-restaurant-noodle.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-restaurant-pizza.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-restaurant-pizza.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-restaurant-seafood.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-restaurant-seafood.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-restaurant.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-restaurant.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-roadblock.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-roadblock.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-rocket.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-rocket.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-school-JP.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-school-JP.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-school.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-school.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-scooter.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-scooter.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-shelter.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-shelter.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-shoe.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-shoe.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-shop.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-shop.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-skateboard.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-skateboard.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-skiing.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-skiing.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-slaughterhouse.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-slaughterhouse.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-slipway.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-slipway.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-snowmobile.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-snowmobile.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-soccer.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-soccer.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-square-stroked.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-square-stroked.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-square.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-square.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-stadium.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-stadium.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-star-stroked.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-star-stroked.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-star.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-star.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-suitcase.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-suitcase.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-sushi.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-sushi.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-swimming.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-swimming.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-table-tennis.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-table-tennis.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-teahouse.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-teahouse.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-telephone.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-telephone.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-tennis.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-tennis.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-theatre.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-theatre.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-toilet.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-toilet.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-town-hall.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-town-hall.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-town.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-town.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-triangle-stroked.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-triangle-stroked.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-triangle.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-triangle.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-veterinary.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-veterinary.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-viewpoint.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-viewpoint.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-village.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-village.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-volcano.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-volcano.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-volleyball.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-volleyball.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-warehouse.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-warehouse.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-waste-basket.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-waste-basket.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-watch.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-watch.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-water.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-water.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-waterfall.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-waterfall.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-watermill.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-watermill.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-wetland.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-wetland.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-wheelchair.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-wheelchair.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-windmill.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-windmill.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/Maki Icons.xcassets/maki-zoo.imageset/Contents.json
+++ b/src/Maki Icons.xcassets/maki-zoo.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-abseiling.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-abseiling.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-accounting.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-accounting.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-adit_profile.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-adit_profile.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-aerialway_pole.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-aerialway_pole.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-amusement_park.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-amusement_park.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-antenna.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-antenna.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-anvil.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-anvil.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-anvil_and_hammer.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-anvil_and_hammer.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-app_terminal.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-app_terminal.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-archery.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-archery.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-army_tent.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-army_tent.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-atm.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-atm.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-balloon.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-balloon.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-barn.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-barn.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-beach.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-beach.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-beauty_salon.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-beauty_salon.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bench.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bench.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-benchmark_disk.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-benchmark_disk.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bicycle_box.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bicycle_box.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bicycle_locker.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bicycle_locker.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bicycle_rental.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bicycle_rental.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bicycle_repair.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bicycle_repair.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bicycle_structure.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bicycle_structure.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-billboard.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-billboard.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-binoculars.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-binoculars.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bleachers.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bleachers.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-blind.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-blind.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-boat.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-boat.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-boat_floating.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-boat_floating.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-boat_ramp.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-boat_ramp.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-boat_rental.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-boat_rental.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-boat_repair.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-boat_repair.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-boat_tour.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-boat_tour.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-boating.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-boating.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bollard.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bollard.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bollard_row.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bollard_row.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-book_store.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-book_store.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bottles.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bottles.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-boulder1.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-boulder1.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-boulder2.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-boulder2.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-boulder3.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-boulder3.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bowling.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bowling.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bowling_alt1.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bowling_alt1.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bread.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bread.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-brick_trowel.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-brick_trowel.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bridge.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bridge.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-briefcase.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-briefcase.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-briefcase_bolt.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-briefcase_bolt.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-briefcase_cross.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-briefcase_cross.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-briefcase_info.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-briefcase_info.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-briefcase_shield.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-briefcase_shield.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-buffer_stop.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-buffer_stop.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bulb.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bulb.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bulb2.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bulb2.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bulb3.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bulb3.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bulldozer.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bulldozer.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bulletin_board.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bulletin_board.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bunk_beds.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bunk_beds.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bunker.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bunker.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-bunker_silo.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-bunker_silo.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-buoy.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-buoy.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-cabin.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-cabin.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-cable.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-cable.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-cable_device.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-cable_device.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-cable_manhole.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-cable_manhole.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-cable_meter.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-cable_meter.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-cable_shutoff.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-cable_shutoff.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-cairn.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-cairn.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-campfire.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-campfire.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-can.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-can.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-canoe.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-canoe.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-car_dealer.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-car_dealer.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-car_parked.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-car_parked.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-car_pool.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-car_pool.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-car_structure.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-car_structure.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-car_wash.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-car_wash.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-casino.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-casino.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-cattle_grid.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-cattle_grid.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-chairlift.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-chairlift.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-checkpoint.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-checkpoint.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-chefs_knife.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-chefs_knife.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-chicane_arrow.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-chicane_arrow.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-chimney.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-chimney.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-chocolate.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-chocolate.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-cleaver.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-cleaver.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-cliff_falling_rocks.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-cliff_falling_rocks.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-climbing.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-climbing.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-clock.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-clock.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-clothes_hanger.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-clothes_hanger.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-coffee.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-coffee.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-compass.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-compass.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-courthouse.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-courthouse.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-crane.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-crane.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-cross_country_skiing.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-cross_country_skiing.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-curtains.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-curtains.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-cycle_barrier.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-cycle_barrier.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-cyclist_crosswalk.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-cyclist_crosswalk.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-dagger.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-dagger.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-desk_lamp.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-desk_lamp.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-diamond.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-diamond.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-dice.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-dice.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-disc_golf_basket.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-disc_golf_basket.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-diving.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-diving.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-dog_shelter.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-dog_shelter.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-domed_tower.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-domed_tower.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-donut.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-donut.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-drag_lift.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-drag_lift.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-dress.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-dress.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-ear.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-ear.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-egg.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-egg.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-electronic.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-electronic.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-elevator.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-elevator.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-embassy.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-embassy.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-fashion_accessories.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-fashion_accessories.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-field_hockey.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-field_hockey.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-fire_hydrant.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-fire_hydrant.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-fireplace.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-fireplace.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-fish_cleaning.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-fish_cleaning.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-fish_ladder.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-fish_ladder.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-fishing_pier.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-fishing_pier.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-florist.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-florist.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-food.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-food.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-fountain.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-fountain.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-furniture.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-furniture.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-gas.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-gas.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-gas_device.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-gas_device.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-gas_manhole.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-gas_manhole.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-gas_meter.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-gas_meter.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-gas_shutoff.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-gas_shutoff.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-gate.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-gate.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-golf_cart.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-golf_cart.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-golf_green.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-golf_green.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-gown.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-gown.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-grapes.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-grapes.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-grass.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-grass.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-guard_rail.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-guard_rail.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-gym.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-gym.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-hair_care.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-hair_care.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-hand.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-hand.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-handbag.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-handbag.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-hang_gliding.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-hang_gliding.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-hearing_aid.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-hearing_aid.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-heart.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-heart.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-hedge.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-hedge.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-height_restrictor.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-height_restrictor.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-hinduism.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-hinduism.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-horse_shelter.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-horse_shelter.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-horseshoe.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-horseshoe.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-horseshoes.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-horseshoes.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-houseboat.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-houseboat.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-ice_fishing.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-ice_fishing.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-ice_skating.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-ice_skating.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-info_board.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-info_board.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-inline_skating.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-inline_skating.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-island_trees_building.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-island_trees_building.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-islet_tree.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-islet_tree.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-j_bar_lift.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-j_bar_lift.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-jet_skiing.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-jet_skiing.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-jewelry_store.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-jewelry_store.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-junction.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-junction.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-junk_car.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-junk_car.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-kayaking.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-kayaking.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-kerb-flush.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-kerb-flush.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-kerb-lowered.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-kerb-lowered.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-kerb-raised.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-kerb-raised.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-kerb-rolled.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-kerb-rolled.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-kitchen_sink.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-kitchen_sink.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-laundry.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-laundry.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-lawn.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-lawn.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-lawyer.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-lawyer.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-letter_box.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-letter_box.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-library.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-library.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-lift_gate.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-lift_gate.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-light_rail.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-light_rail.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-lipstick.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-lipstick.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-lock.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-lock.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-manhole.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-manhole.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-manufactured_home.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-manufactured_home.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-mast.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-mast.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-mast_communication.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-mast_communication.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-milestone.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-milestone.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-military.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-military.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-military_checkpoint.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-military_checkpoint.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-mineshaft_cage.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-mineshaft_cage.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-mineshaft_profile.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-mineshaft_profile.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-money_hand.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-money_hand.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-monorail.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-monorail.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-motorcycle.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-motorcycle.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-motorcycle_rental.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-motorcycle_rental.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-motorcycle_repair.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-motorcycle_repair.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-mountain_range.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-mountain_range.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-movie_rental.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-movie_rental.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-museum.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-museum.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-needle_and_spool.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-needle_and_spool.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-oil_well.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-oil_well.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-parking_space.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-parking_space.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-passport_checkpoint.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-passport_checkpoint.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-ped_cyclist_crosswalk.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-ped_cyclist_crosswalk.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-pedestrian.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-pedestrian.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-pedestrian_and_cyclist.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-pedestrian_and_cyclist.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-pedestrian_crosswalk.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-pedestrian_crosswalk.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-pedestrian_walled.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-pedestrian_walled.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-perfume.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-perfume.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-pet_store.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-pet_store.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-pharmacy.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-pharmacy.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-physiotherapist.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-physiotherapist.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-picnic_shelter.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-picnic_shelter.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-pier_fixed.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-pier_fixed.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-pier_floating.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-pier_floating.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-pin.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-pin.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-pipe.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-pipe.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-plaque.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-plaque.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-platter_lift.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-platter_lift.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-play_structure.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-play_structure.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-plumber.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-plumber.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-police_checkpoint.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-police_checkpoint.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-police_officer.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-police_officer.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-polished_nail.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-polished_nail.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-post_box.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-post_box.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-poster_box.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-poster_box.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-power.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-power.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-power_cb.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-power_cb.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-power_cb2.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-power_cb2.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-power_circuit.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-power_circuit.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-power_ct.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-power_ct.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-power_device.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-power_device.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-power_isolator.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-power_isolator.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-power_la.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-power_la.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-power_manhole.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-power_manhole.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-power_meter.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-power_meter.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-power_shutoff.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-power_shutoff.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-power_switch.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-power_switch.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-power_tower.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-power_tower.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-power_transformer.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-power_transformer.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-propane_tank.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-propane_tank.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-psychic.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-psychic.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-radiation.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-radiation.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-radio.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-radio.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-rafting.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-rafting.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-rail_profile.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-rail_profile.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-railing.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-railing.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-railway_cable_track.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-railway_cable_track.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-railway_signals.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-railway_signals.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-railway_track.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-railway_track.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-railway_track_askew.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-railway_track_askew.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-railway_track_mini.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-railway_track_mini.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-railway_track_narrow.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-railway_track_narrow.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-railway_track_unfinished.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-railway_track_unfinished.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-real_estate_agency.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-real_estate_agency.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-rocket_firework.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-rocket_firework.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-roller_coaster.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-roller_coaster.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-rope_fence.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-rope_fence.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-row_houses.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-row_houses.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-ruins.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-ruins.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-rumble_strip.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-rumble_strip.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-rv_park.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-rv_park.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-saddle.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-saddle.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-sailing.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-sailing.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-sandwich.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-sandwich.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-school.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-school.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-scuba_diving.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-scuba_diving.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-sculpture.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-sculpture.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-security_camera.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-security_camera.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-shield.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-shield.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-shinto.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-shinto.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-shopping_mall.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-shopping_mall.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-shower.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-shower.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-shuffleboard.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-shuffleboard.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-sign_and_bench.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-sign_and_bench.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-sign_and_car.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-sign_and_car.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-sign_and_pedestrian.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-sign_and_pedestrian.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-sikhism.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-sikhism.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-silo.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-silo.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-skateboarding.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-skateboarding.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-ski_jumping.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-ski_jumping.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-skiing.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-skiing.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-sledding.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-sledding.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-sleep_shelter.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-sleep_shelter.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-slide.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-slide.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-snow.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-snow.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-snow_shoeing.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-snow_shoeing.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-snowboarding.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-snowboarding.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-snowmobile.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-snowmobile.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-social_facility.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-social_facility.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-spa.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-spa.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-speaker.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-speaker.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-speed_bump.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-speed_bump.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-speed_dip.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-speed_dip.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-speed_dip_double.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-speed_dip_double.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-speed_hump.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-speed_hump.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-speed_table.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-speed_table.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-spice_bottle.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-spice_bottle.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-spike_strip.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-spike_strip.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-spotting_scope.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-spotting_scope.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-stamp.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-stamp.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-statue.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-statue.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-stile_squeezer.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-stile_squeezer.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-stop.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-stop.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-storage.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-storage.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-storage_drum.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-storage_drum.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-storage_fermenter.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-storage_fermenter.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-storage_rental.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-storage_rental.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-storage_tank.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-storage_tank.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-street_lamp_arm.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-street_lamp_arm.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-striped_way.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-striped_way.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-striped_zone.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-striped_zone.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-subway.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-subway.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-suitcase.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-suitcase.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-suitcase_key.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-suitcase_key.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-suitcase_xray.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-suitcase_xray.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-surfing.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-surfing.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-swamp.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-swamp.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-t_bar_lift.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-t_bar_lift.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-tall_gate.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-tall_gate.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-tanning.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-tanning.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-tanning2.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-tanning2.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-taoism.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-taoism.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-tattoo_machine.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-tattoo_machine.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-taxi_stand.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-taxi_stand.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-telephone.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-telephone.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-telescope.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-telescope.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-temaki.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-temaki.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-tennis.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-tennis.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-ticket.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-ticket.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-tiling.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-tiling.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-tire.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-tire.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-toolbox.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-toolbox.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-tools.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-tools.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-tower.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-tower.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-tower_communication.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-tower_communication.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-traffic_signals.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-traffic_signals.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-tram.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-tram.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-transit.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-transit.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-transit_shelter.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-transit_shelter.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-tree_and_bench.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-tree_and_bench.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-tree_row.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-tree_row.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-trolleybus.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-trolleybus.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-truck.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-truck.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-tunnel.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-tunnel.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-turnstile.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-turnstile.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-utility_pole.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-utility_pole.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vacuum.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vacuum.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-valley.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-valley.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vase.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vase.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_bread.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_bread.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_cigarettes.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_cigarettes.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_cold_drink.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_cold_drink.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_cold_drink2.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_cold_drink2.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_eggs.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_eggs.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_flat_coin.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_flat_coin.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_hot_drink.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_hot_drink.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_hot_drink2.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_hot_drink2.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_ice.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_ice.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_ice_cream.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_ice_cream.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_ice_cream2.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_ice_cream2.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_lockers.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_lockers.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_love.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_love.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_machine.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_machine.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_medicine.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_medicine.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_newspaper.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_newspaper.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_pet_waste.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_pet_waste.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_stamps.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_stamps.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_tickets.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_tickets.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vending_venus.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vending_venus.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-vertex.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-vertex.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-veterinary_care.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-veterinary_care.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-wall.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-wall.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-waste.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-waste.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-waste_device.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-waste_device.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-waste_manhole.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-waste_manhole.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-waste_meter.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-waste_meter.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-waste_shutoff.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-waste_shutoff.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-water.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-water.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-water_device.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-water_device.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-water_manhole.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-water_manhole.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-water_meter.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-water_meter.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-water_shutoff.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-water_shutoff.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-water_tap.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-water_tap.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-water_tap_drinkable.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-water_tap_drinkable.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-water_tower.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-water_tower.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-waterskiing.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-waterskiing.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-well_pump_manual.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-well_pump_manual.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-well_pump_powered.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-well_pump_powered.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-whale_watching.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-whale_watching.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-wheel.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-wheel.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-wheelchair.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-wheelchair.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-wind_surfing.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-wind_surfing.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-wind_turbine.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-wind_turbine.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-windmill.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-windmill.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-window.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-window.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-windsock.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-windsock.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-yield.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-yield.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/src/iOS/Temaki Icons.xcassets/temaki-zoo.imageset/Contents.json
+++ b/src/iOS/Temaki Icons.xcassets/temaki-zoo.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }


### PR DESCRIPTION
This branch resolves #283 by enabling "Preserve Vector Data" for the Maki and Temaki icons.

## Comparison

Before:
![blurry-icons](https://user-images.githubusercontent.com/1681085/76161215-0abe0480-6129-11ea-9d46-2196cb34df44.png)

After:
![blurry-icons-fixed](https://user-images.githubusercontent.com/1681085/76161213-0396f680-6129-11ea-9f63-ba385bbc981a.png)
