### PR TITLE
Bugfix: Fix Dark Mode appearance of Notes

### DIFF
--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -1412,6 +1412,7 @@
                                                         <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" editable="NO" text="Various comments..." translatesAutoresizingMaskIntoConstraints="NO" id="PHk-s9-onx">
                                                             <rect key="frame" x="5" y="0.0" width="253" height="38.5"/>
                                                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                         </textView>

--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -1417,7 +1417,7 @@
                                                             <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                         </textView>
                                                     </subviews>
-                                                    <color key="backgroundColor" red="0.99116724730000005" green="0.5801026225" blue="0.84369850160000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="backgroundColor" systemColor="tertiarySystemBackgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="bottom" secondItem="PHk-s9-onx" secondAttribute="bottom" id="35a-OL-sex"/>
                                                         <constraint firstItem="PHk-s9-onx" firstAttribute="top" secondItem="K4Z-5c-5ee" secondAttribute="top" id="4xG-Gl-OFU"/>

--- a/src/iOS/NotesTableViewController.m
+++ b/src/iOS/NotesTableViewController.m
@@ -92,7 +92,6 @@
 		} else {
 			cell.commentBackground.hidden					= NO;
 			cell.commentBackground.layer.cornerRadius		= 5;
-			cell.commentBackground.layer.backgroundColor	= [UIColor colorWithRed:0.9 green:0.9 blue:1.0 alpha:1.0].CGColor;
 			cell.commentBackground.layer.borderColor		= UIColor.blackColor.CGColor;
 			cell.commentBackground.layer.borderWidth		= 1.0;
 			cell.commentBackground.layer.masksToBounds		= YES;


### PR DESCRIPTION
This branch resolves #279 by using system-provided colors instead of custom ones for the "Notes" view.

## Preview

Regular (light):
![note-regular](https://user-images.githubusercontent.com/1681085/76161599-d3515700-612c-11ea-9f8c-e790099237b1.png)

Dark Mode:
![note-darkmode](https://user-images.githubusercontent.com/1681085/76161604-da786500-612c-11ea-8c51-cb30cc037f8e.png)
