### PR TITLE
Fix label color for Dark Mode in `POICommonTagsViewController`

### DIFF
--- a/src/iOS/POICommonTagsViewController.m
+++ b/src/iOS/POICommonTagsViewController.m
@@ -252,7 +252,6 @@
 		cell.nameLabel.text = commonTag.name;
 		cell.valueField.placeholder = commonTag.placeholder;
 		cell.valueField.delegate = self;
-		cell.valueField.textColor = [UIColor colorWithRed:0.22 green:0.33 blue:0.53 alpha:1.0];
 		cell.commonTag = commonTag;
 
 		cell.valueField.keyboardType = commonTag.keyboardType;


### PR DESCRIPTION
By removing the static color that is set in code, the color is controlled by the system and adapts to Dark Mode.

## Before

![common-tags-dark-before](https://user-images.githubusercontent.com/1681085/76577050-f462d080-64bb-11ea-84ed-2edddf9f1c87.png)

## After

![common-tags-dark-after](https://user-images.githubusercontent.com/1681085/76577048-f3ca3a00-64bb-11ea-9fcc-427f2eb2e67c.png)
