### PR TITLE
Feature: Use circle for nodes on the map

### DIFF
--- a/src/Shared/EditorMapLayer.m
+++ b/src/Shared/EditorMapLayer.m
@@ -1606,6 +1606,8 @@ const static CGFloat Z_ARROWS			= Z_BASE + 11 * ZSCALE;
         backgroundLayer.cornerRadius        = MinIconSizeInPixels / 2;
         backgroundLayer.masksToBounds     = YES;
         backgroundLayer.anchorPoint = CGPointZero;
+        backgroundLayer.borderColor = UIColor.darkGrayColor.CGColor;
+        backgroundLayer.borderWidth = 0.5;
         
         /// The actual icon image serves as a `mask` for the icon's color layer, allowing for "tinting" of the icons.
         CALayer *iconMaskLayer = [CALayer new];

--- a/src/Shared/EditorMapLayer.m
+++ b/src/Shared/EditorMapLayer.m
@@ -1611,7 +1611,8 @@ const static CGFloat Z_ARROWS			= Z_BASE + 11 * ZSCALE;
         
         /// The actual icon image serves as a `mask` for the icon's color layer, allowing for "tinting" of the icons.
         CALayer *iconMaskLayer = [CALayer new];
-        iconMaskLayer.frame            = CGRectMake(0, 0, MinIconSizeInPixels, MinIconSizeInPixels);
+        CGFloat padding = 4;
+        iconMaskLayer.frame            = CGRectMake(padding, padding, MinIconSizeInPixels - padding * 2, MinIconSizeInPixels - padding * 2);
         iconMaskLayer.contents            = (id)icon.CGImage;
         
         CALayer *iconLayer = [CALayer new];

--- a/src/Shared/EditorMapLayer.m
+++ b/src/Shared/EditorMapLayer.m
@@ -1603,7 +1603,7 @@ const static CGFloat Z_ARROWS			= Z_BASE + 11 * ZSCALE;
         CALayer *backgroundLayer = [CALayer new];
         backgroundLayer.bounds            = CGRectMake(0, 0, MinIconSizeInPixels, MinIconSizeInPixels);
         backgroundLayer.backgroundColor     = [UIColor colorWithWhite:1.0 alpha:0.75].CGColor;
-        backgroundLayer.cornerRadius        = 5;
+        backgroundLayer.cornerRadius        = MinIconSizeInPixels / 2;
         backgroundLayer.masksToBounds     = YES;
         backgroundLayer.anchorPoint = CGPointZero;
         


### PR DESCRIPTION
This branch changes the white box behind nodes on the map, making them appear in a circle.

## Before
![icon-circle-before](https://user-images.githubusercontent.com/1681085/76577935-c59a2980-64be-11ea-9c98-816cdb12acb0.png)

## After
![icon-circle-after](https://user-images.githubusercontent.com/1681085/76577932-c468fc80-64be-11ea-89c1-6e2d497fa31f.png)




