### PR TITLE
Use the JOSM layer index

### DIFF
--- a/src/Shared/AerialList.m
+++ b/src/Shared/AerialList.m
@@ -670,7 +670,7 @@ static NSString * CUSTOMAERIALSELECTION_KEY = @"AerialListSelection";
 	NSDate * lastDownload = [[NSUserDefaults standardUserDefaults] objectForKey:@"lastImageryDownloadDate"];
 	if ( cachedData == nil || (lastDownload && [now timeIntervalSinceDate:lastDownload] >= 60*60*24*7) ) {
 		// download newer version periodically
-		NSString * urlString = @"https://osmlab.github.io/editor-layer-index/imagery.geojson";
+		NSString * urlString = @"https://josm.openstreetmap.de/maps?format=geojson";
 		NSURL * downloadUrl = [NSURL URLWithString:urlString];
 		NSURLSessionDataTask * downloadTask = [[NSURLSession sharedSession] dataTaskWithURL:downloadUrl completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
 			[[NSUserDefaults standardUserDefaults] setObject:now forKey:@"lastImageryDownloadDate"];


### PR DESCRIPTION
iD is switching to its own thing, so the Editor Layer Index will inevitably receive less updates. The JOSM index already has more and more up-to-date layers. Both indexes are under the same CC-BY-SA license.