### PR TITLE
Fix: Flickering of panel after selecting preset

### DIFF
--- a/src/iOS/POICommonTagsViewController.m
+++ b/src/iOS/POICommonTagsViewController.m
@@ -125,24 +125,30 @@
 	if ( [self isMovingToParentViewController] ) {
 	} else {
 		[self updatePresets];
-
-		// special case: if this is a new object and the user just selected the feature to be shop/amenity,
-		// then automatically select the Name field as the first responder
-		POITabBarController * tabController = (id)self.tabBarController;
-		if ( tabController.isTagDictChanged ) {
-			NSDictionary * dict = tabController.keyValueDict;
-			if ( dict.count == 1 && dict[@"shop"] && dict[@"name"] == nil ) {
-				// find name field and make it first responder
-				dispatch_async(dispatch_get_main_queue(), ^{
-					NSIndexPath * index = [NSIndexPath indexPathForRow:1 inSection:0];
-					CommonTagCell * cell = [self.tableView cellForRowAtIndexPath:index];
-					if ( cell && [cell.commonTag.tagKey isEqualToString:@"name"] ) {
-						[cell.valueField becomeFirstResponder];
-					}
-				});
-			}
-		}
 	}
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    
+    if (![self isMovingToParentViewController]) {
+        // special case: if this is a new object and the user just selected the feature to be shop/amenity,
+        // then automatically select the Name field as the first responder
+        POITabBarController * tabController = (id)self.tabBarController;
+        if ( tabController.isTagDictChanged ) {
+            NSDictionary * dict = tabController.keyValueDict;
+            if ( dict.count == 1 && dict[@"shop"] && dict[@"name"] == nil ) {
+                // find name field and make it first responder
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    NSIndexPath * index = [NSIndexPath indexPathForRow:1 inSection:0];
+                    CommonTagCell * cell = [self.tableView cellForRowAtIndexPath:index];
+                    if ( cell && [cell.commonTag.tagKey isEqualToString:@"name"] ) {
+                        [cell.valueField becomeFirstResponder];
+                    }
+                });
+            }
+        }
+    }
 }
 
 -(void)viewWillDisappear:(BOOL)animated

--- a/src/iOS/POICommonTagsViewController.m
+++ b/src/iOS/POICommonTagsViewController.m
@@ -131,7 +131,7 @@
 		POITabBarController * tabController = (id)self.tabBarController;
 		if ( tabController.isTagDictChanged ) {
 			NSDictionary * dict = tabController.keyValueDict;
-			if ( dict.count == 1 && (dict[@"shop"] || dict[@"amenity"]) && dict[@"name"] == nil ) {
+			if ( dict.count == 1 && dict[@"shop"] && dict[@"name"] == nil ) {
 				// find name field and make it first responder
 				dispatch_async(dispatch_get_main_queue(), ^{
 					NSIndexPath * index = [NSIndexPath indexPathForRow:1 inSection:0];

--- a/src/iOS/POICommonTagsViewController.m
+++ b/src/iOS/POICommonTagsViewController.m
@@ -137,7 +137,7 @@
         POITabBarController * tabController = (id)self.tabBarController;
         if ( tabController.isTagDictChanged ) {
             NSDictionary * dict = tabController.keyValueDict;
-            if ( dict.count == 1 && dict[@"shop"] && dict[@"name"] == nil ) {
+            if ( dict.count == 1 && (dict[@"shop"] || dict[@"amenity"]) && dict[@"name"] == nil ) {
                 // find name field and make it first responder
                 dispatch_async(dispatch_get_main_queue(), ^{
                     NSIndexPath * index = [NSIndexPath indexPathForRow:1 inSection:0];


### PR DESCRIPTION
This branch fixes #282 by only attempting to select the "name" field for presets with the tag "shop"; not for "amenity" ones.

In addition, I moved the code for displaying the keyboard to `viewDidAppear:`, which make sure that it is displayed _after_ the "POI Type" view controller was dismissed.