### PR TITLE
Add natural=tree_row based on barrier=hedge

### DIFF
--- a/src/Shared/RenderInfo.xml
+++ b/src/Shared/RenderInfo.xml
@@ -21,6 +21,7 @@
 
 	<default key="amenity" type="node;area" areaColor="F7EFB7" />
 
+	<tag key="barrier" value="tree_row" type="way;node_in_way" lineColor="A0F0A0" lineWidth="1.000000" areaColor="008000"/>
 	<tag key="barrier" value="hedge" type="way;node_in_way" lineColor="A0F0A0" lineWidth="1.000000" areaColor="C0FFC0"/>
 	<default key="barrier" type="way;node_in_way" lineColor="F0F050" lineWidth="1.000000"/>
 


### PR DESCRIPTION
Use the fill color of wood from https://github.com/bryceco/GoMap/blob/master/src/Shared/RenderInfo.xml#L131

Closes https://github.com/bryceco/GoMap/issues/329
Wiki: https://wiki.openstreetmap.org/wiki/Tag:natural%3Dtree_row

----

This change is done "blindly" on the website, so it might in fact be completely wrong :-).
But just in case it is easier to merge this way, I proposed it anyway :).