### PR TITLE
Fix: Don't display a footer text that says "Results for null (null)"

### DIFF
--- a/src/iOS/POIFeaturePickerViewController.m
+++ b/src/iOS/POIFeaturePickerViewController.m
@@ -112,6 +112,12 @@ static PersistentWebCache * logoCache;	// static so memory cache persists each t
 		NSString * countryCode = AppDelegate.shared.mapView.countryCodeForLocation;
 		NSLocale * locale = [NSLocale currentLocale];
 		NSString * countryName = [locale displayNameForKey:NSLocaleCountryCode value:countryCode];
+        
+        if (countryCode.length == 0 || countryName.length == 0) {
+            // There's nothing to display.
+            return nil;
+        }
+        
 		return [NSString stringWithFormat:NSLocalizedString(@"Results for %@ (%@)",nil),countryName,countryCode.uppercaseString];
 	}
 	return nil;


### PR DESCRIPTION
This branch resolves an issue where, when `AppDelegate.shared.mapView.countryCodeForLocation` was `nil`, the footer text of the POI feature picker would read "Result for (null) ((null))".

## Before

![result-for-null-null-before](https://user-images.githubusercontent.com/1681085/92089367-5991e180-edce-11ea-8891-308e4e611ee4.png)

## After

![result-for-null-null-after](https://user-images.githubusercontent.com/1681085/92089379-5e569580-edce-11ea-9eb1-5f7ffcb13a1c.png)
