### PR TITLE
Setup fastlane for Beta distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ DerivedData/
 # Misc
 .svn
 .DS_Store
+
+# Build results
+*.dSYM.zip
+*.ipa

--- a/README.md
+++ b/README.md
@@ -10,6 +10,33 @@ Go Map!! is an iPhone/iPad editor for adding cartographic information to [OpenSt
 Do you want to help testing pre-releases of Go Map!!?
 [Become a TestFlight tester][4] today! 🚀
 
+## Continuous integration
+
+### Prerequisite
+
+- Make sure you have _fastlane_ installed. (From a terminal, change to the `src/iOS` directory and run `bundle install`.)
+- Since _fastlane_ stores your provisioning profiles and certificates in a Git repository (`MATCH_REPO`), you need to create a new, empty repository if you haven't already. The profiles and certificates are protected by a password (`MATCH_PASSWORD`).
+- When creating the Beta locally, _fastlane_ will make sure that your certificates and provisioning profiles are up-to-date.
+
+### How to release a Beta locally
+
+You'll need to obtain the values for the following parameter:
+
+- `MATCH_REPO`: The URL to the Git repository that contains the provisioning profiles/certificates
+- `MATCH_PASSWORD`: The password for encrypting/decrypting the provisioning profiles/certificates
+- `FASTLANE_TEAM_ID`: The ID of the developer team at developer.apple.com
+- `FASTLANE_USER`: The email address that is used to sign in to App Store Connect
+- `FASTLANE_ITC_TEAM_ID`: The ID of the team at appstoreconnect.apple.com
+
+In order to release a new Beta to the TestFlight testers, run
+
+    % MATCH_REPO=<GIT_REPOSITORY_URL> \
+      MATCH_PASSWORD=<MATCH_PASSWORD> \
+      FASTLANE_TEAM_ID=<APPLE_DEVELOPER_TEAM_ID> \
+      FASTLANE_USER=<APP_STORE_CONNECT_EMAIL> \
+      FASTLANE_ITC_TEAM_ID=<APP_STORE_CONNECT_TEAM_ID> \
+      bundle exec fastlane beta
+
 ## Source code structure
 
 * iOS - Code specific to the iOS app

--- a/src/iOS/Go Map!!-Info.plist
+++ b/src/iOS/Go Map!!-Info.plist
@@ -61,7 +61,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>1950</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/src/iOS/Go Map!!-Info.plist
+++ b/src/iOS/Go Map!!-Info.plist
@@ -41,7 +41,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>1.9.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -1371,6 +1371,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -1400,6 +1401,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/Go Map!!-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -1284,6 +1284,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MARKETING_VERSION = 1.9.5;
 				ONLY_ACTIVE_ARCH = YES;
 				PROVISIONING_PROFILE = "";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
@@ -1334,6 +1335,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MARKETING_VERSION = 1.9.5;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				PROVISIONING_PROFILE = "";
@@ -1430,6 +1432,7 @@
 				INFOPLIST_FILE = GoMapTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.9.5;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bryceco.GoMapTests;
@@ -1468,6 +1471,7 @@
 				INFOPLIST_FILE = GoMapTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.9.5;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bryceco.GoMapTests;
@@ -1501,6 +1505,7 @@
 				INFOPLIST_FILE = GoMapUITests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.9.5;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bryceco.GoMapUITests;
@@ -1537,6 +1542,7 @@
 				INFOPLIST_FILE = GoMapUITests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.9.5;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bryceco.GoMapUITests;

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -1359,7 +1359,7 @@
 				DISPLAY_NAME = "Go Map!! Debug";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Go Map!!-Prefix.pch";
-				INFOPLIST_FILE = "$(SRCROOT)/Go Map!!-Info.plist";
+				INFOPLIST_FILE = "Go Map!!-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.9.5;
@@ -1390,7 +1390,7 @@
 				DISPLAY_NAME = "Go Map!!";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Go Map!!-Prefix.pch";
-				INFOPLIST_FILE = "$(SRCROOT)/Go Map!!-Info.plist";
+				INFOPLIST_FILE = "Go Map!!-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.9.5;

--- a/src/iOS/Go Map!!.xcodeproj/xcshareddata/xcschemes/Go Map!!.xcscheme
+++ b/src/iOS/Go Map!!.xcodeproj/xcshareddata/xcschemes/Go Map!!.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "02ACBA2E16713CCB00BB4414"
+               BuildableName = "Go Map!!.app"
+               BlueprintName = "Go Map!!"
+               ReferencedContainer = "container:Go Map!!.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "de"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "02ACBA2E16713CCB00BB4414"
+            BuildableName = "Go Map!!.app"
+            BlueprintName = "Go Map!!"
+            ReferencedContainer = "container:Go Map!!.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "02ACBA2E16713CCB00BB4414"
+            BuildableName = "Go Map!!.app"
+            BlueprintName = "Go Map!!"
+            ReferencedContainer = "container:Go Map!!.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/src/iOS/Go Map!!.xcodeproj/xcshareddata/xcschemes/Go Map!!.xcscheme
+++ b/src/iOS/Go Map!!.xcodeproj/xcshareddata/xcschemes/Go Map!!.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "64348CE9225E7CD900ADE7FB"
+               BuildableName = "GoMapTests.xctest"
+               BlueprintName = "GoMapTests"
+               ReferencedContainer = "container:Go Map!!.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/src/iOS/GoMapTests/Info.plist
+++ b/src/iOS/GoMapTests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>1950</string>
 </dict>
 </plist>

--- a/src/iOS/GoMapTests/Info.plist
+++ b/src/iOS/GoMapTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.9.5</string>
 	<key>CFBundleVersion</key>
 	<string>1950</string>
 </dict>

--- a/src/iOS/GoMapUITests/Info.plist
+++ b/src/iOS/GoMapUITests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>1950</string>
 </dict>
 </plist>

--- a/src/iOS/GoMapUITests/Info.plist
+++ b/src/iOS/GoMapUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.9.5</string>
 	<key>CFBundleVersion</key>
 	<string>1950</string>
 </dict>

--- a/src/iOS/fastlane/Fastfile
+++ b/src/iOS/fastlane/Fastfile
@@ -75,6 +75,17 @@ platform :ios do
       xcodeproj: './Go Map!!.xcodeproj',
       message: 'Bump build number and version'
     )
+
+    build_app(
+      project: "Go Map!!.xcodeproj",
+      scheme: "Go Map!!"
+    )
+
+    add_git_tag(tag: get_version_number())
+
+    push_to_git_remote
+
+    upload_to_testflight
   end
 
 end

--- a/src/iOS/fastlane/Fastfile
+++ b/src/iOS/fastlane/Fastfile
@@ -38,4 +38,14 @@ platform :ios do
     )
   end
 
+  desc "Builds and uploads a new TestFlight Beta release."
+  lane :beta do
+    UI.message("Preparing new TestFlight release...")
+
+    # Make sure that all tests run successfully.
+    pull_request_checks
+
+    create_private_keychain
+  end
+
 end

--- a/src/iOS/fastlane/Fastfile
+++ b/src/iOS/fastlane/Fastfile
@@ -7,6 +7,18 @@ private_keychain_password = "does-not-matter"
 
 default_platform(:ios)
 
+# Determines the bundle identifier based on the given target name.
+# Source: https://stackoverflow.com/a/42610380
+def product_bundle_id(scheme)
+  # The working directory of fastlane actions is the `./fastlane` folder,
+  # so in order to access the project file, we need to use "../".
+  project = Xcodeproj::Project.open("../Go Map!!.xcodeproj")
+
+  scheme = project.native_targets.find { |target| target.name == scheme }
+  build_configuration = scheme.build_configurations.first
+  build_configuration.build_settings['PRODUCT_BUNDLE_IDENTIFIER']
+end
+
 platform :ios do
 
   desc "Creates a private Keychain. This is needed so that the Beta can be created by a GitHub Action."
@@ -46,6 +58,15 @@ platform :ios do
     pull_request_checks
 
     create_private_keychain
+
+    # Get the provisioning profiles and certificates.
+    match(
+      type: "appstore",
+      readonly: is_ci,
+      keychain_name: private_keychain_name,
+      keychain_password: private_keychain_password,
+      app_identifier: product_bundle_id("Go Map!!")
+    )
 
     # Bump the build number and the version.
     increment_build_number

--- a/src/iOS/fastlane/Fastfile
+++ b/src/iOS/fastlane/Fastfile
@@ -1,9 +1,26 @@
 # Disable metrics
 opt_out_usage
 
+# Configuration
+private_keychain_name = "fastlane_keychain"
+private_keychain_password = "does-not-matter"
+
 default_platform(:ios)
 
 platform :ios do
+
+  desc "Creates a private Keychain. This is needed so that the Beta can be created by a GitHub Action."
+  private_lane :create_private_keychain do
+    # See: https://medium.com/well-red/github-actions-fastlane-ios-1f6d43cce726
+    create_keychain(
+      name: private_keychain_name,
+      password: private_keychain_password,
+      default_keychain: true,
+      unlock: true,
+      timeout: 3600,
+      lock_when_sleeps: false
+    )
+  end
 
   desc "Performs basic integration checks to be run before merging"
   lane :pull_request_checks do

--- a/src/iOS/fastlane/Fastfile
+++ b/src/iOS/fastlane/Fastfile
@@ -46,6 +46,14 @@ platform :ios do
     pull_request_checks
 
     create_private_keychain
+
+    # Bump the build number and the version.
+    increment_build_number
+    increment_version_number(bump_type: 'patch')
+    commit_version_bump(
+      xcodeproj: './Go Map!!.xcodeproj',
+      message: 'Bump build number and version'
+    )
   end
 
 end

--- a/src/iOS/fastlane/README.md
+++ b/src/iOS/fastlane/README.md
@@ -26,6 +26,11 @@ Performs basic integration checks to be run before merging
 fastlane ios regenerate_app_icon
 ```
 Re-generates the app icon from the base app_icon.png in the fastlane metadata directory
+### ios beta
+```
+fastlane ios beta
+```
+Builds and uploads a new TestFlight Beta release.
 
 ----
 


### PR DESCRIPTION
This pull request prepares the fully automated release process (cp. #426) by adding a _fastlane_ lane that allows for the Beta to be tested, build and signed automatically.

As per the updated README:

> In order to release a new Beta to the TestFlight testers, run
> 
>      % MATCH_REPO=<GIT_REPOSITORY_URL> \
>        MATCH_PASSWORD=<MATCH_PASSWORD> \
>        FASTLANE_TEAM_ID=<APPLE_DEVELOPER_TEAM_ID> \
>        FASTLANE_USER=<APP_STORE_CONNECT_EMAIL> \
>        FASTLANE_ITC_TEAM_ID=<APP_STORE_CONNECT_TEAM_ID> \
>        bundle exec fastlane beta