### PR TITLE
Add type-hinting for arrays that contain `CALayer`s with `properties`

### DIFF
--- a/src/Shared/EditorMapLayer.m
+++ b/src/Shared/EditorMapLayer.m
@@ -1207,7 +1207,7 @@ const static CGFloat Z_HIGHLIGHT_ARROW	= Z_BASE + 14 * ZSCALE;
 	return wall;
 }
 
--(NSArray *)getShapeLayersForObject:(OsmBaseObject *)object
+-(NSArray<CALayer<LayerPropertiesProviding> *> *)getShapeLayersForObject:(OsmBaseObject *)object
 {
 	if ( object.shapeLayers )
 		return object.shapeLayers;
@@ -1524,9 +1524,9 @@ const static CGFloat Z_HIGHLIGHT_ARROW	= Z_BASE + 14 * ZSCALE;
  */
 - (NSArray<CALayer *> *)shapeLayersForNode:(OsmNode *)node
 {
-    NSMutableArray<CALayer *> *layers = [NSMutableArray array];
+    NSMutableArray<CALayer<LayerPropertiesProviding> *> *layers = [NSMutableArray array];
     
-    NSArray<CALayer *> *directionLayers = [self directionShapeLayersWithNode:node];
+    NSArray<CALayer<LayerPropertiesProviding> *> *directionLayers = [self directionShapeLayersWithNode:node];
     if (directionLayers) {
 		[layers addObjectsFromArray:directionLayers];
     }
@@ -1644,7 +1644,7 @@ const static CGFloat Z_HIGHLIGHT_ARROW	= Z_BASE + 14 * ZSCALE;
 }
 
 
-- (CALayer *)directionShapeLayerForNode:(OsmNode *)node withDirection:(NSRange)direction
+- (CALayer<LayerPropertiesProviding> *)directionShapeLayerForNode:(OsmNode *)node withDirection:(NSRange)direction
 {
 	CGFloat heading = direction.location - 90.0;
 	if ( direction.length )
@@ -1707,7 +1707,7 @@ const static CGFloat Z_HIGHLIGHT_ARROW	= Z_BASE + 14 * ZSCALE;
  @param node The node to get the layer for.
  @return A `CALayer` instance for rendering the given node's direction.
  */
-- (NSArray<CALayer *> *)directionShapeLayersWithNode:(OsmNode *)node
+- (NSArray<CALayer<LayerPropertiesProviding> *> *)directionShapeLayersWithNode:(OsmNode *)node
 {
     NSRange direction = node.direction;
 	if (direction.location != NSNotFound) {
@@ -2391,9 +2391,9 @@ const static CGFloat Z_HIGHLIGHT_ARROW	= Z_BASE + 14 * ZSCALE;
 
 	for ( OsmBaseObject * object in _shownObjects ) {
 
-		NSArray * layers = [self getShapeLayersForObject:object];
+		NSArray<CALayer<LayerPropertiesProviding> *> * layers = [self getShapeLayersForObject:object];
 
-		for ( CALayerWithProperties * layer in layers ) {
+		for ( CALayer<LayerPropertiesProviding> * layer in layers ) {
 
 			// configure the layer for presentation
 			BOOL isShapeLayer = [layer isKindOfClass:[CAShapeLayer class]];

--- a/src/Shared/LayerProperties.h
+++ b/src/Shared/LayerProperties.h
@@ -25,16 +25,19 @@ NS_ASSUME_NONNULL_BEGIN
 }
 @end
 
-@interface CALayerWithProperties : CALayer
+@protocol LayerPropertiesProviding
+
 @property (readonly) LayerProperties * properties;
+
 @end
 
-@interface CAShapeLayerWithProperties : CAShapeLayer
-@property (readonly) LayerProperties * properties;
+@interface CALayerWithProperties : CALayer <LayerPropertiesProviding>
 @end
 
-@interface CATextLayerWithProperties : CATextLayer
-@property (readonly) LayerProperties * properties;
+@interface CAShapeLayerWithProperties : CAShapeLayer <LayerPropertiesProviding>
+@end
+
+@interface CATextLayerWithProperties : CATextLayer <LayerPropertiesProviding>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/Shared/LayerProperties.m
+++ b/src/Shared/LayerProperties.m
@@ -19,6 +19,7 @@
 @end
 
 @implementation CALayerWithProperties
+@synthesize properties = _properties;
 -(instancetype)init
 {
 	if ( self = [super init] ) {
@@ -26,9 +27,11 @@
 	}
 	return self;
 }
+
 @end
 
 @implementation CAShapeLayerWithProperties
+@synthesize properties = _properties;
 -(instancetype)init
 {
 	if ( self = [super init] ) {
@@ -39,6 +42,7 @@
 @end
 
 @implementation CATextLayerWithProperties
+@synthesize properties = _properties;
 -(instancetype)init
 {
 	if ( self = [super init] ) {

--- a/src/Shared/OSMModels/OsmBaseObject.h
+++ b/src/Shared/OSMModels/OsmBaseObject.h
@@ -77,7 +77,7 @@ NSDictionary * MergeTags(NSDictionary * myself, NSDictionary * tags, BOOL failOn
 
 // extra stuff
 @property (readonly,nonatomic)    OSMRect				boundingBox;
-@property (strong,nonatomic)    NSArray            *   	shapeLayers;
+@property (strong,nonatomic)    NSArray<CALayer<LayerPropertiesProviding> *>            *   	shapeLayers;
 @property (readonly,nonatomic)    ONEWAY               	isOneWay;
 @property (assign,nonatomic)    TRISTATE            	isShown;
 


### PR DESCRIPTION
This branch adds type-hinting to the arrays that contain `CALayer` subclasses that are expected to have `properties`.

By using a protocol and the base class `CALayer`, we can now tell that an array contains instances of `CALayer<LayerPropertiesProviding>`.