### PR TITLE
Refactoring: Remove warnings

### DIFF
--- a/src/Shared/CurvedTextLayer.swift
+++ b/src/Shared/CurvedTextLayer.swift
@@ -229,11 +229,6 @@ import QuartzCore
         var currentCharacter: CFIndex = 0
         var currentPixelOffset = offset
         while currentCharacter < charCount {
-            if currentCharacter > 0, isRTL, false {
-                // doesn't fit on one segment so give up
-                return nil
-            }
-
             // get the number of characters that fit in the current path segment and create a text layer for it
             guard var loc = PositionAndAngleForOffset(points: pathPoints,
                                                       offset: currentPixelOffset,

--- a/src/iOS/GoMapTests/Mocks/MeasureDirectionViewModelDelegateMock.swift
+++ b/src/iOS/GoMapTests/Mocks/MeasureDirectionViewModelDelegateMock.swift
@@ -16,7 +16,7 @@ class MeasureDirectionViewModelDelegateMock: NSObject {
 }
 
 extension MeasureDirectionViewModelDelegateMock: MeasureDirectionViewModelDelegate {
-    func didFinishUpdatingTag(key: String, value: String?) {
+    func didFinishUpdatingTag(key: String, value: String) {
         didFinishUpdatingTagCalled = true
 
         self.key = key


### PR DESCRIPTION
This branch removes two warnings that were displayed in Xcode when building/testing/running the `master` branch.