### PR TITLE
Re-enable "Go Map!! Debug" as the display name for DEBUG builds

### DIFF
--- a/src/iOS/Go Map!!-Info.plist
+++ b/src/iOS/Go Map!!-Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>${DISPLAY_NAME}</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This partially reverts commit c63e3523aed25b28241d61c32291999974041117.