### PR TITLE
Delete private keychain after creating the beta

### DIFF
--- a/src/iOS/fastlane/Fastfile
+++ b/src/iOS/fastlane/Fastfile
@@ -86,6 +86,8 @@ platform :ios do
       scheme: "Go Map!!"
     )
 
+    delete_private_keychain
+
     add_git_tag(tag: get_version_number())
 
     push_to_git_remote

--- a/src/iOS/fastlane/Fastfile
+++ b/src/iOS/fastlane/Fastfile
@@ -34,6 +34,11 @@ platform :ios do
     )
   end
 
+  desc "Deletes the privat Keychain that is used with GitHub Actions."
+  private_lane :delete_private_keychain do
+    delete_keychain(name: private_keychain_name)
+  end
+
   desc "Performs basic integration checks to be run before merging"
   lane :pull_request_checks do
     run_tests(


### PR DESCRIPTION
This gets rid of the annoying popup that @bryceco [reported](https://github.com/bryceco/GoMap/issues/426#issuecomment-692289477) by deleting the private Keychain after creating the Beta build.