### PR TITLE
Fix failing `PresetKeyTagCase`

### DIFF
--- a/src/iOS/GoMapTests/PresetKeyTagCase.swift
+++ b/src/iOS/GoMapTests/PresetKeyTagCase.swift
@@ -14,35 +14,35 @@ class PresetKeyTagCase: XCTestCase {
     func testInitWithPresetsShouldPreferThePlaceholderParameterIfProvided() {
         let placeholder = "Lorem ipsum"
 
-        let firstPreset = PresetValue(name: "Ja", details: "", tagValue: "yes").require()
-        let secondPreset = PresetValue(name: "Nein", details: "", tagValue: "no").require()
+        let firstPreset = PresetValue(name: "Ja", details: "", tagValue: "yes")
+        let secondPreset = PresetValue(name: "Nein", details: "", tagValue: "no")
 
         let tagKey = PresetKey(name: "Rückenlehne",
-                               featureKey: "backreset",
+                               tagKey: "backreset",
                                defaultValue: nil,
                                placeholder: placeholder,
                                keyboard: .default,
                                capitalize: .none,
                                presets: [firstPreset, secondPreset])
 
-        XCTAssertEqual(tagKey.require().placeholder, placeholder)
+        XCTAssertEqual(tagKey.placeholder, placeholder)
     }
 
     func testInitWithPresetsShouldUseTheirNamesForPlaceholder() {
         let firstPresetName = "Ja"
-        let firstPreset = PresetValue(name: firstPresetName, details: "", tagValue: "yes").require()
+        let firstPreset = PresetValue(name: firstPresetName, details: "", tagValue: "yes")
 
         let secondPresentName = "Nein"
-        let secondPreset = PresetValue(name: secondPresentName, details: "", tagValue: "no").require()
+        let secondPreset = PresetValue(name: secondPresentName, details: "", tagValue: "no")
 
         let tagKey = PresetKey(name: "Rückenlehne",
-                               featureKey: "backreset",
+                               tagKey: "backreset",
                                defaultValue: nil,
                                placeholder: nil,
                                keyboard: .default,
                                capitalize: .none,
                                presets: [firstPreset, secondPreset])
 
-        XCTAssertEqual(tagKey.require().placeholder, "\(firstPresetName), \(secondPresentName)...")
+        XCTAssertEqual(tagKey.placeholder, "\(firstPresetName), \(secondPresentName)...")
     }
 }


### PR DESCRIPTION
With the conversion of `PresetKeyTag`, the initializer no longer returns an optional, removing the need to use `.require()` here.

Side note: We might have discovered this earlier if we had continuous integration in place (#420).