### PR TITLE
Let the help button on the map be a full circle

### DIFF
--- a/src/iOS/MainViewController.m
+++ b/src/iOS/MainViewController.m
@@ -121,7 +121,10 @@
 	for ( UIButton * button in buttons ) {
 
 		// corners
-		if ( button != _mapView.compassButton ) {
+        if ( button == _mapView.helpButton ) {
+            // The button is a circle.
+            button.layer.cornerRadius = button.bounds.size.width / 2;
+        } else if ( button != _mapView.compassButton ) {
 			button.layer.cornerRadius	= button == _mapView.addNodeButton ? 30.0 : 10.0;
 		}
 		// shadow


### PR DESCRIPTION
This fixes the help button at the top left corner of the map, which should be a round circle.

### Before
![help-button-current](https://user-images.githubusercontent.com/1681085/104838034-ae834f80-58b8-11eb-9b41-44531644655e.png)

### After
![help-button-full-circle](https://user-images.githubusercontent.com/1681085/104838036-b04d1300-58b8-11eb-960b-a9e64087e6e6.png)