### PR TITLE
Refactoring: Remove `details` property from `PresetValue`

### DIFF
--- a/src/Shared/PresetsDatabase/PresetValue.swift
+++ b/src/Shared/PresetsDatabase/PresetValue.swift
@@ -12,23 +12,19 @@ import Foundation
 // A possible value for a preset key
 @objc class PresetValue: NSCoder {
 	@objc let name: String
-	@objc let details: String?
 	@objc let tagValue: String
 
 	@objc init(name: String?, tagValue value: String) {
 		self.name = name ?? OsmTags.PrettyTag(value)
-		self.details = nil
 		self.tagValue = value
 	}
 
 	@objc func encode(withCoder coder: NSCoder) {
 		coder.encode(name, forKey: "name")
-		coder.encode(details, forKey: "details")
 		coder.encode(tagValue, forKey: "tagValue")
 	}
 
 	@objc required init?(withCoder coder: NSCoder) {
-		self.details = coder.decodeObject(forKey: "details") as? String
 		if let name = coder.decodeObject(forKey: "name") as? String,
 		   let tagValue = coder.decodeObject(forKey: "tagValue") as? String
 		{

--- a/src/Shared/PresetsDatabase/PresetValue.swift
+++ b/src/Shared/PresetsDatabase/PresetValue.swift
@@ -15,9 +15,9 @@ import Foundation
 	@objc let details: String?
 	@objc let tagValue: String
 
-	@objc init(name: String?, details: String?, tagValue value: String) {
+	@objc init(name: String?, tagValue value: String) {
 		self.name = name ?? OsmTags.PrettyTag(value)
-		self.details = details
+		self.details = nil
 		self.tagValue = value
 	}
 

--- a/src/Shared/PresetsDatabase/PresetsDatabase+TableView.swift
+++ b/src/Shared/PresetsDatabase/PresetsDatabase+TableView.swift
@@ -268,8 +268,8 @@ extension PresetsDatabase {
 
 		case "defaultcheck", "check", "onewayCheck":
 			let presets = [
-				PresetValue(name: PresetsDatabase.shared.yesForLocale, details: nil, tagValue: "yes"),
-				PresetValue(name: PresetsDatabase.shared.noForLocale, details: nil, tagValue: "no")
+				PresetValue(name: PresetsDatabase.shared.yesForLocale, tagValue: "yes"),
+				PresetValue(name: PresetsDatabase.shared.noForLocale, tagValue: "no")
 			]
 			let tag = PresetKey(name: label!, tagKey: key, defaultValue: defaultValue, placeholder: placeholder, keyboard: keyboard, capitalize: capitalize, presets: presets)
 			let group = PresetGroup(name:nil, tags:[tag])
@@ -281,8 +281,8 @@ extension PresetsDatabase {
 
 				// a list of booleans
 				let presets = [
-					PresetValue(name: PresetsDatabase.shared.yesForLocale, details: nil, tagValue: "yes"),
-					PresetValue(name: PresetsDatabase.shared.noForLocale, details: nil, tagValue: "no")
+					PresetValue(name: PresetsDatabase.shared.yesForLocale, tagValue: "yes"),
+					PresetValue(name: PresetsDatabase.shared.noForLocale, tagValue: "no")
 				]
 				var tags: [PresetKey] = []
 				for k in keysArray {
@@ -300,7 +300,7 @@ extension PresetsDatabase {
 					guard let v = v as? String else {
 						continue
 					}
-					presets.append(PresetValue(name: nil, details: nil, tagValue: v))
+					presets.append(PresetValue(name: nil, tagValue: v))
 				}
 				let tag = PresetKey(name: label!, tagKey: key, defaultValue: defaultValue, placeholder: placeholder, keyboard: keyboard, capitalize: UITextAutocapitalizationType.none, presets: presets)
 				let group = PresetGroup(name: nil, tags: [tag])
@@ -310,7 +310,7 @@ extension PresetsDatabase {
 				// a multiple selection
 				var presets: [PresetValue] = []
 				for (val2,prettyName) in stringsOptionsDict as! [String:String] {
-					let p = PresetValue(name: prettyName, details: nil, tagValue: val2)
+					let p = PresetValue(name: prettyName, tagValue: val2)
 					presets.append(p)
 				}
 				let tag = PresetKey(name: label!, tagKey: key, defaultValue: defaultValue, placeholder: placeholder, keyboard: keyboard, capitalize: UITextAutocapitalizationType.none, presets: presets)
@@ -336,7 +336,7 @@ extension PresetsDatabase {
 			if let stringsOptionsDict = stringsOptionsDict {
 
 				for (k,v) in stringsOptionsDict as! [String:String] {
-					presets.append(PresetValue(name: v, details: nil, tagValue: k))
+					presets.append(PresetValue(name: v, tagValue: k))
 				}
 				presets.sort(by: { (obj1, obj2) -> Bool in
 					return obj1.name < obj2.name
@@ -345,7 +345,7 @@ extension PresetsDatabase {
 
 				for v in optionsArray {
 					if let v = v as? String {
-						presets.append(PresetValue(name: nil, details: nil, tagValue: v))
+						presets.append(PresetValue(name: nil, tagValue: v))
 					}
 				}
 
@@ -385,8 +385,8 @@ extension PresetsDatabase {
 								// a list of booleans
 								var tags: [PresetKey] = []
 								let yesNo = [
-									PresetValue(name: PresetsDatabase.shared.yesForLocale, details: nil, tagValue: "yes"),
-									PresetValue(name: PresetsDatabase.shared.noForLocale, details: nil, tagValue: "no")
+									PresetValue(name: PresetsDatabase.shared.yesForLocale, tagValue: "yes"),
+									PresetValue(name: PresetsDatabase.shared.noForLocale, tagValue: "no")
 								]
 								for v in values ?? [] {
 									guard let v = v as? [AnyHashable : Any] else {
@@ -417,7 +417,7 @@ extension PresetsDatabase {
 										continue // it's a very uncommon value, so ignore it
 									}
 									if let val = v["value"] as? String {
-										presetList.append(PresetValue(name: nil, details: nil, tagValue: val))
+										presetList.append(PresetValue(name: nil, tagValue: val))
 									}
 								}
 								presets2 = presetList
@@ -453,7 +453,7 @@ extension PresetsDatabase {
 				var presets: [PresetValue] = []
 				for (k,v) in stringsOptionsDict as? [String:[String:String]] ?? [:] {
 					let n = v["title"]
-                    presets.append(PresetValue(name: n, details: nil, tagValue: k))
+                    presets.append(PresetValue(name: n, tagValue: k))
 				}
 				let name = (stringsTypesDict?[key] as? String) ?? OsmTags.PrettyTag(type!)
 				let tag = PresetKey(name: name, tagKey: key, defaultValue: defaultValue, placeholder: placeholder, keyboard: keyboard, capitalize: UITextAutocapitalizationType.none, presets: presets)
@@ -537,7 +537,7 @@ extension PresetsDatabase {
 			// special case
 			var presets: [PresetValue] = []
 			for (k,info) in stringsOptionsDict as! [String:[String:Any]] {
-				let v = PresetValue(name: info["title"] as? String, details: nil, tagValue: k)
+				let v = PresetValue(name: info["title"] as? String, tagValue: k)
 				presets.append(v)
 			}
 

--- a/src/Shared/PresetsDatabase/PresetsDatabase+TableView.swift
+++ b/src/Shared/PresetsDatabase/PresetsDatabase+TableView.swift
@@ -453,8 +453,7 @@ extension PresetsDatabase {
 				var presets: [PresetValue] = []
 				for (k,v) in stringsOptionsDict as? [String:[String:String]] ?? [:] {
 					let n = v["title"]
-					let d = v["description"]
-					presets.append(PresetValue(name: n, details: d, tagValue: k))
+                    presets.append(PresetValue(name: n, details: nil, tagValue: k))
 				}
 				let name = (stringsTypesDict?[key] as? String) ?? OsmTags.PrettyTag(type!)
 				let tag = PresetKey(name: name, tagKey: key, defaultValue: defaultValue, placeholder: placeholder, keyboard: keyboard, capitalize: UITextAutocapitalizationType.none, presets: presets)
@@ -538,7 +537,7 @@ extension PresetsDatabase {
 			// special case
 			var presets: [PresetValue] = []
 			for (k,info) in stringsOptionsDict as! [String:[String:Any]] {
-				let v = PresetValue(name: info["title"] as? String, details: info["description"] as? String, tagValue: k)
+				let v = PresetValue(name: info["title"] as? String, details: nil, tagValue: k)
 				presets.append(v)
 			}
 

--- a/src/iOS/CustomPresetController.m
+++ b/src/iOS/CustomPresetController.m
@@ -50,7 +50,7 @@
 	for ( UITextField * field in _valueFieldList ) {
 		NSString * value = [field.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 		if ( value.length ) {
-			PresetValue * preset = [[PresetValue alloc] initWithName:nil details:nil tagValue:value];
+			PresetValue * preset = [[PresetValue alloc] initWithName:nil tagValue:value];
 			[presets addObject:preset];
 		}
 	}

--- a/src/iOS/GoMapTests/PresetKeyTagCase.swift
+++ b/src/iOS/GoMapTests/PresetKeyTagCase.swift
@@ -14,8 +14,8 @@ class PresetKeyTagCase: XCTestCase {
     func testInitWithPresetsShouldPreferThePlaceholderParameterIfProvided() {
         let placeholder = "Lorem ipsum"
 
-        let firstPreset = PresetValue(name: "Ja", details: "", tagValue: "yes")
-        let secondPreset = PresetValue(name: "Nein", details: "", tagValue: "no")
+        let firstPreset = PresetValue(name: "Ja", tagValue: "yes")
+        let secondPreset = PresetValue(name: "Nein", tagValue: "no")
 
         let tagKey = PresetKey(name: "Rückenlehne",
                                tagKey: "backreset",
@@ -30,10 +30,10 @@ class PresetKeyTagCase: XCTestCase {
 
     func testInitWithPresetsShouldUseTheirNamesForPlaceholder() {
         let firstPresetName = "Ja"
-        let firstPreset = PresetValue(name: firstPresetName, details: "", tagValue: "yes")
+        let firstPreset = PresetValue(name: firstPresetName, tagValue: "yes")
 
         let secondPresentName = "Nein"
-        let secondPreset = PresetValue(name: secondPresentName, details: "", tagValue: "no")
+        let secondPreset = PresetValue(name: secondPresentName, tagValue: "no")
 
         let tagKey = PresetKey(name: "Rückenlehne",
                                tagKey: "backreset",

--- a/src/iOS/POIPresetValuePickerController.m
+++ b/src/iOS/POIPresetValuePickerController.m
@@ -49,14 +49,10 @@
 	UITableViewCell *cell;
 	PresetValue * preset = _valueDefinitions[ indexPath.row ];
 
-	if ( preset.details )
-		cell = [tableView dequeueReusableCellWithIdentifier:@"SubtitleCell" forIndexPath:indexPath];
-	else
-		cell = [tableView dequeueReusableCellWithIdentifier:@"BasicCell" forIndexPath:indexPath];
+    cell = [tableView dequeueReusableCellWithIdentifier:@"BasicCell" forIndexPath:indexPath];
 
 	if ( preset.name ) {
 		cell.textLabel.text = preset.name;
-		cell.detailTextLabel.text = preset.details;
 	} else {
 		NSString * text = [preset.tagValue stringByReplacingOccurrencesOfString:@"_" withString:@" "];
 		text = [text capitalizedString];


### PR DESCRIPTION
Maybe I am mistaken, but I had a very thorough look at the presets that GoMap currently ships with, and I was unable to find where this "description" was coming from. I also had a look at the OSM wiki, but came up empty.

From my perspective, it looks as if this property can be removed.