### PR TITLE
Fix terms

### DIFF
--- a/src/Shared/PresetsDatabase/PresetFeature.swift
+++ b/src/Shared/PresetsDatabase/PresetFeature.swift
@@ -48,11 +48,11 @@ import Foundation
 		self._removeTags = jsonDict["removeTags"] as? [String: String]
 		self.searchable = jsonDict["searchable"] as? Bool ?? true
 		self.tags = jsonDict["tags"] as! [String: String]
-        if let terms = jsonDict["terms"] as? String {
-            self.terms = terms.split(separator: ",").compactMap { "\($0)" }
-        } else {
-            self.terms = jsonDict["terms"] as? [String] ?? jsonDict["matchNames"] as? [String] ?? []
-        }
+		if let terms = jsonDict["terms"] as? String {
+			self.terms = terms.split(separator: ",").compactMap { "\($0)" }
+		} else {
+			self.terms = jsonDict["terms"] as? [String] ?? jsonDict["matchNames"] as? [String] ?? []
+		}
 		self.nsiSuggestion = isNSI
 	}
 

--- a/src/Shared/PresetsDatabase/PresetFeature.swift
+++ b/src/Shared/PresetsDatabase/PresetFeature.swift
@@ -48,8 +48,11 @@ import Foundation
 		self._removeTags = jsonDict["removeTags"] as? [String: String]
 		self.searchable = jsonDict["searchable"] as? Bool ?? true
 		self.tags = jsonDict["tags"] as! [String: String]
-		self.terms = jsonDict["terms"] as? [String] ?? jsonDict["matchNames"] as? [String] ?? []
-
+        if let terms = jsonDict["terms"] as? String {
+            self.terms = terms.split(separator: ",").compactMap { "\($0)" }
+        } else {
+            self.terms = jsonDict["terms"] as? [String] ?? jsonDict["matchNames"] as? [String] ?? []
+        }
 		self.nsiSuggestion = isNSI
 	}
 


### PR DESCRIPTION
The term in the translation file is a comma separated string, not an array of strings

https://github.com/openstreetmap/id-tagging-schema/blob/main/dist/translations/en.json#L3363
```
amenity/school": {
    "name":"School Grounds",
    "terms":"academy,elementary school,middle school,high school"
}
```
![image](https://user-images.githubusercontent.com/1942091/111861119-d78e9200-8986-11eb-8a84-d276f1bacd45.png)


