### PR TITLE
Fixed transparent background in nominatim search

### DIFF
--- a/src/iOS/Storyboards/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Storyboards/Base.lproj/MainStoryboard.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="2">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="2">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -868,6 +868,7 @@
                             </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="JYP-Gu-HBL"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="abd-jd-9tI" firstAttribute="top" secondItem="xw9-Ro-Fai" secondAttribute="bottom" id="2UE-0c-j5w"/>
                             <constraint firstItem="JYP-Gu-HBL" firstAttribute="trailing" secondItem="Kw9-Kv-I2B" secondAttribute="trailing" id="63I-uY-OYs"/>


### PR DESCRIPTION
With iOS 15 the nominatim search view controller navigation bar had a transparent background:
<img width="487" alt="Screen Shot 2021-12-06 at 08 04 00" src="https://user-images.githubusercontent.com/132167/144802853-49ec0566-b354-4d6a-b604-37b48b3f2f5d.png">

This is how it looks now on iOS 15:
<img width="487" alt="Screen Shot 2021-12-06 at 08 05 21" src="https://user-images.githubusercontent.com/132167/144802887-ff95dbb5-0631-4643-a2d6-28dfec4ff4af.png">


