### PR TITLE
Initial version of changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,261 @@
+# Changelog
+
+11:03 7 "
+
+*)
+:
+
+<€ Back
+
+Version History
+
+3.1.0
+
+* All Tags now has a Feature picker
+
+* Supports double-tap and drag for zooming
+
+* Aerial imagery providers now highlight "best"
+layers
+
+* Fixes issues with autocomplete
+
+* Crash fixes
+
+* Updated translations
+
+* Mac Catalyst improvements
+
+*
+
+3.0.0
+
+* Now written in Swift!
+
+* Support for many new languages
+
+* Improves support when sharing GPX files or
+URLs to the app
+
+* Improved search: search by lat/lon, OSM node/
+way ID, etc.
+
+* Many bug fixes and minor improvements
+
+2.2.1
+
+* Various bug fixes
+
+* Adds support for Mac Catalyst
+
+* Improved internationalization and languages
+
+* Adds camera-based reading of opening_hours
+on signs
+
+2.1.2
+
+* Updated translations, presets, and name
+suggestion index
+
+* New Yes/No switches for boolean presets
+
+* Multi-Combo presets (such as "Diet Types" are
+now presented in prettier and more compact
+manner
+
+* Various bug fixes
+
+* Drops support for iOS 9
+
+2.0.7
+
+New look, new presets!
+
+Now fully localized for Russian, Japanese,
+French and Croatian
+
+Mostly localized for Chinese (Traditional and
+Simplified), Norwegian, Finnish and German
+
+1.8.42 ly ago
+
+Fixes a bug preventing OSM data from being
+downloaded.
+
+1.8.41 ly ago
+
+Fixes a bug causing the map location to reset on
+older devices
+
+1.8.4 ly ago
+* Fix a bug where tag values were sometimes set
+incorrectly
+
+* Allow zooming out a greater amount when
+editing sparse, rural areas.
+
+1.8.2
+
+Bug fixes
+
+Support brand name suggestions
+Redesign of All Tags view
+Performance improvements
+Many small Ul improvements
+
+1.7.1
+
+* Fixes an issue where presets for a feature were
+not correctly populated.
+
+* Adds Beta testing & GitHub information to
+Contact Us
+
+1.7.0
+
+* Updated presets
+* Dark mode and other UI improvements
+* Various bug fixes and improvements
+
+1.6.1
+
+Fixes a crash when editing a multipolygon that is
+only partially downloaded.
+
+1.6
+
+* Bug fixes and usability improvements
+
+* Support for creating and editing multipolygon
+relations
+
+* Much improved detection of edits that damage
+relations
+
+* Now trims the object cache automatically as
+needed
+
+* Supports dynamic type, allowing font size to be
+adjusted
+
+* Upload screen now contains links back to
+modified objects
+
+1.5.3
+
+- Fixes crash during launch
+
+1.5.2
+
+Bug fixes:
+
+- payment:* and service:* tags incorrectly
+formatted
+
+- crash when a relation contains itself as a
+member
+
+1.5.1
+
+« Updated for iOS 11 and iPhone X
+
+- Updated presets
+
+« Multilingual presets (select language in
+Settings pane)
+
+- Turn restriction editor
+
+- Duplicate and rotate objects
+
+« Record GPX tracks in the background
+
+« Support for many more background image
+sources
+
+- Shows compass heading
+
+- App badge display number of pending edits
+« Connect to alternate OSM servers
+
+1.5
+
+- Updated for iOS 11 and iPhone X
+
+- Updated presets
+
+- Multilingual presets (select language in
+Settings pane)
+
+- Turn restriction editor
+
+- Duplicate and rotate objects
+
+« Record GPX tracks in the background
+
+« Support for many more background image
+sources
+
+- Shows compass heading
+
+- App badge display number of pending edits
+« Connect to alternate OSM servers
+
+1.4
+
+- Updated for iOS 9
+
+- Faster and more stable
+
+- iD based preset categories
+
+- Create, upload and download GPX traces
+- Create and resolve Notes
+
+- Rotated and birds-eye (3-D) views
+
+1.3.1
+
+Fixes an issue with Undo introduced by version
+1.3
+
+1.3
+
+Version 1.3 features improved graphics
+performance, map rotation, and new editing
+options.
+
+1.2.1
+
+- Updated for iOS 8
+
+« New editing commands: Copy/Paste tags, Join,
+Split, Straighten, etc.
+
+« Customizable backgrounds, including MapBox
+and OSM GPS traces
+
+- Improved presets for common types of objects
+- Define your own presets
+
+- Performance improvements
+
+1.1
+
+* Improved tagging for highways and ways
+
+* Autocomplete for tag keys and values
+
+* Fixes font issues affecting Asian and Russian
+street names
+
+* More icons for points of interest
+
+* Various bug fixes and other improvements
+
+1.0
+
+Q
+
+Search

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.1.0
 
-- All Tags now has a Feature picker
+- 'All Tags' tab now has a Feature picker
 - Supports double-tap and drag for zooming
 - Aerial imagery providers now highlight "best" layers
 - Fixes issues with autocomplete
@@ -29,7 +29,7 @@
 
 - Updated translations, presets, and name suggestion index
 - New Yes/No switches for boolean presets
-- Multi-Combo presets (such as "Diet Types" are now presented in prettier and more compact manner
+- Multi-Combo presets (such as "Diet Types") are now presented in prettier and more compact manner
 - Various bug fixes
 - Drops support for iOS 9
 
@@ -56,14 +56,14 @@ Fixes a bug causing the map location to reset on older devices
 
 - Bug fixes
 - Support brand name suggestions
-- Redesign of All Tags view
+- Redesign of 'All Tags' view
 - Performance improvements
 - Many small Ul improvements
 
 ## 1.7.1
 
 - Fixes an issue where presets for a feature were not correctly populated.
-- Adds Beta testing & GitHub information to Contact Us
+- Adds Beta testing & GitHub information to 'Contact Us'
 
 ## 1.7.0
 
@@ -92,14 +92,14 @@ Fixes a crash when editing a multipolygon that is only partially downloaded.
 
 Bug fixes:
 
-- payment:* and service:* tags incorrectly formatted
+-`payment:*` and `service:*` tags incorrectly formatted
 - crash when a relation contains itself as a member
 
 ## 1.5.1
 
 - Updated for iOS 11 and iPhone X
 - Updated presets
-- Multilingual presets (select language in Settings pane)
+- Multilingual presets (select language in 'Settings' pane)
 - Turn restriction editor
 - Duplicate and rotate objects
 - Record GPX tracks in the background
@@ -112,7 +112,7 @@ Bug fixes:
 
 - Updated for iOS 11 and iPhone X
 - Updated presets
-- Multilingual presets (select language in Settings pane)
+- Multilingual presets (select language in 'Settings' pane)
 - Turn restriction editor
 - Duplicate and rotate objects
 - Record GPX tracks in the background

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,261 +1,158 @@
 # Changelog
 
-11:03 7 "
+## 3.1.0
 
-*)
-:
+- All Tags now has a Feature picker
+- Supports double-tap and drag for zooming
+- Aerial imagery providers now highlight "best" layers
+- Fixes issues with autocomplete
+- Crash fixes
+- Updated translations
+- Mac Catalyst improvements
 
-<€ Back
+## 3.0.0
 
-Version History
+- Now written in Swift!
+- Support for many new languages
+- Improves support when sharing GPX files or URLs to the app
+- Improved search: search by lat/lon, OSM node/way ID, etc.
+- Many bug fixes and minor improvements
 
-3.1.0
+## 2.2.1
 
-* All Tags now has a Feature picker
+- Various bug fixes
+- Adds support for Mac Catalyst
+- Improved internationalization and languages
+- Adds camera-based reading of `opening_hours` on signs
 
-* Supports double-tap and drag for zooming
+## 2.1.2
 
-* Aerial imagery providers now highlight "best"
-layers
+- Updated translations, presets, and name suggestion index
+- New Yes/No switches for boolean presets
+- Multi-Combo presets (such as "Diet Types" are now presented in prettier and more compact manner
+- Various bug fixes
+- Drops support for iOS 9
 
-* Fixes issues with autocomplete
+## 2.0.7
 
-* Crash fixes
+- New look, new presets!
+- Now fully localized for Russian, Japanese, French and Croatian
+- Mostly localized for Chinese (Traditional and Simplified), Norwegian, Finnish and German
 
-* Updated translations
+## 1.8.42
 
-* Mac Catalyst improvements
+Fixes a bug preventing OSM data from being downloaded.
 
-*
+## 1.8.41
 
-3.0.0
+Fixes a bug causing the map location to reset on older devices
 
-* Now written in Swift!
+## 1.8.4
 
-* Support for many new languages
+- Fix a bug where tag values were sometimes set incorrectly
+- Allow zooming out a greater amount when editing sparse, rural areas.
 
-* Improves support when sharing GPX files or
-URLs to the app
+## 1.8.2
 
-* Improved search: search by lat/lon, OSM node/
-way ID, etc.
+- Bug fixes
+- Support brand name suggestions
+- Redesign of All Tags view
+- Performance improvements
+- Many small Ul improvements
 
-* Many bug fixes and minor improvements
+## 1.7.1
 
-2.2.1
+- Fixes an issue where presets for a feature were not correctly populated.
+- Adds Beta testing & GitHub information to Contact Us
 
-* Various bug fixes
+## 1.7.0
 
-* Adds support for Mac Catalyst
+- Updated presets
+- Dark mode and other UI improvements
+- Various bug fixes and improvements
 
-* Improved internationalization and languages
+## 1.6.1
 
-* Adds camera-based reading of opening_hours
-on signs
+Fixes a crash when editing a multipolygon that is only partially downloaded.
 
-2.1.2
+## 1.6
 
-* Updated translations, presets, and name
-suggestion index
+- Bug fixes and usability improvements
+- Support for creating and editing multipolygon relations
+- Much improved detection of edits that damage relations
+- Now trims the object cache automatically as needed
+- Supports dynamic type, allowing font size to be adjusted
+- Upload screen now contains links back to modified objects
 
-* New Yes/No switches for boolean presets
-
-* Multi-Combo presets (such as "Diet Types" are
-now presented in prettier and more compact
-manner
-
-* Various bug fixes
-
-* Drops support for iOS 9
-
-2.0.7
-
-New look, new presets!
-
-Now fully localized for Russian, Japanese,
-French and Croatian
-
-Mostly localized for Chinese (Traditional and
-Simplified), Norwegian, Finnish and German
-
-1.8.42 ly ago
-
-Fixes a bug preventing OSM data from being
-downloaded.
-
-1.8.41 ly ago
-
-Fixes a bug causing the map location to reset on
-older devices
-
-1.8.4 ly ago
-* Fix a bug where tag values were sometimes set
-incorrectly
-
-* Allow zooming out a greater amount when
-editing sparse, rural areas.
-
-1.8.2
-
-Bug fixes
-
-Support brand name suggestions
-Redesign of All Tags view
-Performance improvements
-Many small Ul improvements
-
-1.7.1
-
-* Fixes an issue where presets for a feature were
-not correctly populated.
-
-* Adds Beta testing & GitHub information to
-Contact Us
-
-1.7.0
-
-* Updated presets
-* Dark mode and other UI improvements
-* Various bug fixes and improvements
-
-1.6.1
-
-Fixes a crash when editing a multipolygon that is
-only partially downloaded.
-
-1.6
-
-* Bug fixes and usability improvements
-
-* Support for creating and editing multipolygon
-relations
-
-* Much improved detection of edits that damage
-relations
-
-* Now trims the object cache automatically as
-needed
-
-* Supports dynamic type, allowing font size to be
-adjusted
-
-* Upload screen now contains links back to
-modified objects
-
-1.5.3
+## 1.5.3
 
 - Fixes crash during launch
 
-1.5.2
+## 1.5.2
 
 Bug fixes:
 
-- payment:* and service:* tags incorrectly
-formatted
+- payment:* and service:* tags incorrectly formatted
+- crash when a relation contains itself as a member
 
-- crash when a relation contains itself as a
-member
-
-1.5.1
-
-« Updated for iOS 11 and iPhone X
-
-- Updated presets
-
-« Multilingual presets (select language in
-Settings pane)
-
-- Turn restriction editor
-
-- Duplicate and rotate objects
-
-« Record GPX tracks in the background
-
-« Support for many more background image
-sources
-
-- Shows compass heading
-
-- App badge display number of pending edits
-« Connect to alternate OSM servers
-
-1.5
+## 1.5.1
 
 - Updated for iOS 11 and iPhone X
-
 - Updated presets
-
-- Multilingual presets (select language in
-Settings pane)
-
+- Multilingual presets (select language in Settings pane)
 - Turn restriction editor
-
 - Duplicate and rotate objects
-
-« Record GPX tracks in the background
-
-« Support for many more background image
-sources
-
+- Record GPX tracks in the background
+- Support for many more background image sources
 - Shows compass heading
-
 - App badge display number of pending edits
-« Connect to alternate OSM servers
+- Connect to alternate OSM servers
 
-1.4
+## 1.5
+
+- Updated for iOS 11 and iPhone X
+- Updated presets
+- Multilingual presets (select language in Settings pane)
+- Turn restriction editor
+- Duplicate and rotate objects
+- Record GPX tracks in the background
+- Support for many more background image sources
+- Shows compass heading
+- App badge display number of pending edits
+- Connect to alternate OSM servers
+
+## 1.4
 
 - Updated for iOS 9
-
 - Faster and more stable
-
 - iD based preset categories
-
 - Create, upload and download GPX traces
 - Create and resolve Notes
-
 - Rotated and birds-eye (3-D) views
 
-1.3.1
+## 1.3.1
 
-Fixes an issue with Undo introduced by version
-1.3
+Fixes an issue with Undo introduced by version 1.3
 
-1.3
+## 1.3
 
-Version 1.3 features improved graphics
-performance, map rotation, and new editing
-options.
+Version 1.3 features improved graphics performance, map rotation, and new editing options.
 
-1.2.1
+## 1.2.1
 
 - Updated for iOS 8
-
-« New editing commands: Copy/Paste tags, Join,
-Split, Straighten, etc.
-
-« Customizable backgrounds, including MapBox
-and OSM GPS traces
-
+- New editing commands: Copy/Paste tags, Join, Split, Straighten, etc.
+- Customizable backgrounds, including MapBox and OSM GPS traces
 - Improved presets for common types of objects
 - Define your own presets
-
 - Performance improvements
 
-1.1
+## 1.1
 
-* Improved tagging for highways and ways
+- Improved tagging for highways and ways
+- Autocomplete for tag keys and values
+- Fixes font issues affecting Asian and Russian street names
+- More icons for points of interest
+- Various bug fixes and other improvements
 
-* Autocomplete for tag keys and values
-
-* Fixes font issues affecting Asian and Russian
-street names
-
-* More icons for points of interest
-
-* Various bug fixes and other improvements
-
-1.0
-
-Q
-
-Search
+## 1.0


### PR DESCRIPTION
This relates to #436 and eventually aims to 'fix' the issue.

I made screenshots from the 'Version history' from the [App Store].
These screenshots were then stitched together with successive pairwise stitching in [Fiji].
This resulting image was then piped through `tesseract image.tif history` and copied to CHANGELOG.md for an initial version of the file.

Subsequent commits aim at cleaning up the file, making it more markdowns and proof-reading it.

[App Store]: https://apps.apple.com/ch/app/go-map/id592990211?l=en
[Fiji]: https://imagej.net/plugins/image-stitching#pairwise-stitching