### PR TITLE
add fallback to other name:* tags for friendly name

### DIFF
--- a/src/Shared/OSMModels/OsmBaseObject.swift
+++ b/src/Shared/OSMModels/OsmBaseObject.swift
@@ -531,9 +531,21 @@ class OsmBaseObject: NSObject, NSCoding, NSCopying {
 		"living_street": .name
 	]
 	func givenName() -> String? {
-		if let name = tags["name"] {
+		//first try name tag
+        if let name = tags["name"] {
 			return name
 		}
+        //then try name:en
+        if let name = tags["name:en"] {
+            return name
+        }
+        //then try any other name:* tag
+        if let name = tags.filter({ key, _ in
+            key.starts(with: "name:")
+        }).first?.value {
+            return name
+        }
+        //for ways, use ref tag
 		if isWay() != nil,
 		   let highway = tags["highway"],
 		   let uses = OsmBaseObject.givenNameHighwayTypes[highway],
@@ -542,6 +554,7 @@ class OsmBaseObject: NSObject, NSCoding, NSCopying {
 		{
 			return name
 		}
+        //final fallback use brand
 		return tags["brand"]
 	}
 

--- a/src/Shared/OSMModels/OsmBaseObject.swift
+++ b/src/Shared/OSMModels/OsmBaseObject.swift
@@ -540,9 +540,9 @@ class OsmBaseObject: NSObject, NSCoding, NSCopying {
             return name
         }
         //then try any other name:* tag
-        if let name = tags.filter({ key, _ in
+        if let name = tags.first(where: { key, _ in
             key.starts(with: "name:")
-        }).first?.value {
+        })?.value {
             return name
         }
         //for ways, use ref tag


### PR DESCRIPTION
fixes #611 

after fix applied, `name:en` or other `name:*` tags will be used if there is no `name` tag

![Simulator Screen Shot - iPod touch (7th generation) - 2022-07-30 at 16 26 56](https://user-images.githubusercontent.com/152770/181904520-beb3923e-229c-41b2-91c6-36bf90c87cf1.png)
![Simulator Screen Shot - iPod touch (7th generation) - 2022-07-30 at 16 33 08](https://user-images.githubusercontent.com/152770/181904546-5c85a728-ac65-4b97-a322-749eed1e5012.png)

