### PR TITLE
use Default LSHandlerRank for gpx files

### DIFF
--- a/src/iOS/Go Map!!-Info.plist
+++ b/src/iOS/Go Map!!-Info.plist
@@ -16,7 +16,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
 			<key>LSHandlerRank</key>
-			<string>Owner</string>
+			<string>Default</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>org.gnu.gnu-zip-archive</string>


### PR DESCRIPTION
Use Default handler rank so that users
with multiple apps that can open gpx files
can still use them easily. Default handler
rank makes it easy to open any GPX with
any app that supports it. Owner LSHandlerRank
is problematic because users must go through
a convoluted set of steps to open GPX files
in another app.