### PR TITLE
Enable TelephoneToolbar for KeyValueTableCell

### DIFF
--- a/src/iOS/POI/KeyValueTableCell.swift
+++ b/src/iOS/POI/KeyValueTableCell.swift
@@ -156,6 +156,12 @@ class KeyValueTableCell: TextPairTableCell, UITextFieldDelegate, UITextViewDeleg
 		if let preset = owner.allPresetKeys.first(where: { key == $0.tagKey }) {
 			text2.autocapitalizationType = preset.autocapitalizationType
 			text2.autocorrectionType = preset.autocorrectType
+			text2.keyboardType = preset.keyboardType
+
+			if preset.keyboardType == .phonePad {
+				text2.inputAccessoryView = TelephoneToolbar(forTextField: text2, frame: frame)
+			}
+
 			if preset.type == "textarea" {
 				useTextView()
 			} else {
@@ -167,6 +173,12 @@ class KeyValueTableCell: TextPairTableCell, UITextFieldDelegate, UITextViewDeleg
 				text2.autocapitalizationType = .sentences
 				text2.autocorrectionType = .yes
 				useTextView()
+			case "phone", "contact:phone", "fax", "contact:fax":
+				text2.keyboardType = .phonePad
+				text2.inputAccessoryView = TelephoneToolbar(forTextField: text2, frame: frame)
+				text2.autocapitalizationType = .none
+				text2.autocorrectionType = .no
+				useTextField()
 			default:
 				text2.autocapitalizationType = .none
 				text2.autocorrectionType = .no

--- a/src/iOS/POI/KeyValueTableCell.swift
+++ b/src/iOS/POI/KeyValueTableCell.swift
@@ -160,6 +160,8 @@ class KeyValueTableCell: TextPairTableCell, UITextFieldDelegate, UITextViewDeleg
 
 			if preset.keyboardType == .phonePad {
 				text2.inputAccessoryView = TelephoneToolbar(forTextField: text2, frame: frame)
+			} else {
+				text2.inputAccessoryView = nil
 			}
 
 			if preset.type == "textarea" {


### PR DESCRIPTION
This PR enables the new `TelephoneToolbar` for the `KeyValueTableCell` which was discussed. See #511 