### PR TITLE
Show only one distance unit in ruler

### DIFF
--- a/src/Shared/MapTransform.swift
+++ b/src/Shared/MapTransform.swift
@@ -295,6 +295,13 @@ final class MapTransform {
 		return meters
 	}
 
+	func distance(from: CGPoint, to: CGPoint) -> Double {
+		let c1 = latLon(forScreenPoint: from)
+		let c2 = latLon(forScreenPoint: to)
+		let meters = GreatCircleDistance(c1, c2)
+		return meters
+	}
+
 	func screenPoint(on object: OsmBaseObject, forScreenPoint point: CGPoint) -> CGPoint {
 		let latLon = latLon(forScreenPoint: point)
 		let latLon2 = object.latLonOnObject(forLatLon: latLon)

--- a/src/Shared/MapView.swift
+++ b/src/Shared/MapView.swift
@@ -1326,6 +1326,10 @@ final class MapView: UIView, MapViewProgress, CLLocationManagerDelegate, UIActio
 		return mapTransform.metersPerPixel(atScreenPoint: crossHairs.position)
 	}
 
+	func distance(from: CGPoint, to: CGPoint) -> Double {
+		return mapTransform.distance(from: from, to: to)
+	}
+
 	func boundingMapRectForScreen() -> OSMRect {
 		let rc = OSMRect(layer.bounds)
 		return mapTransform.boundingMapRect(forScreenRect: rc)

--- a/src/iOS/Base.lproj/MainStoryboard.storyboard
+++ b/src/iOS/Base.lproj/MainStoryboard.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="2">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="2">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -39,10 +39,10 @@
                                 </connections>
                             </view>
                             <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TJj-HW-GPO" customClass="RulerView" customModule="Go_Map__" customModuleProvider="target">
-                                <rect key="frame" x="12" y="723" width="120" height="30"/>
+                                <rect key="frame" x="12" y="738" width="120" height="15"/>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="30" id="9lX-7p-riE"/>
+                                    <constraint firstAttribute="height" constant="15" id="9lX-7p-riE"/>
                                     <constraint firstAttribute="width" constant="120" id="IbR-gh-YSN"/>
                                 </constraints>
                             </view>
@@ -943,6 +943,7 @@
                                             <constraint firstAttribute="trailing" secondItem="mhx-8A-Atc" secondAttribute="trailing" constant="8" id="SAA-bu-ylY"/>
                                             <constraint firstAttribute="trailing" secondItem="qP9-Sc-sc4" secondAttribute="trailing" id="eLm-Cg-DhZ"/>
                                             <constraint firstItem="mhx-8A-Atc" firstAttribute="top" secondItem="qP9-Sc-sc4" secondAttribute="bottom" constant="8" id="hX2-cC-Fk1"/>
+                                            <constraint firstItem="qP9-Sc-sc4" firstAttribute="top" secondItem="APA-kz-Xeq" secondAttribute="top" id="muZ-Rz-g9e"/>
                                         </constraints>
                                     </view>
                                 </subviews>
@@ -962,7 +963,6 @@
                             <constraint firstItem="0as-7d-L0W" firstAttribute="leading" secondItem="fg1-MM-IyW" secondAttribute="leading" id="U3F-vT-3NH"/>
                             <constraint firstAttribute="trailing" secondItem="0as-7d-L0W" secondAttribute="trailing" id="Udi-0g-Cm3"/>
                             <constraint firstItem="Mms-6q-xZ5" firstAttribute="bottom" secondItem="0as-7d-L0W" secondAttribute="bottom" id="XT2-Cq-fUX"/>
-                            <constraint firstItem="qP9-Sc-sc4" firstAttribute="top" secondItem="APA-kz-Xeq" secondAttribute="top" id="muZ-Rz-g9e"/>
                         </constraints>
                     </view>
                     <connections>
@@ -1020,13 +1020,13 @@
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="labelColor">
-            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBlueColor">
-            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="tertiarySystemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/src/iOS/CustomViews/RulerView.swift
+++ b/src/iOS/CustomViews/RulerView.swift
@@ -119,11 +119,14 @@ class RulerView: UIView {
 	}
 
 	private func updateText() {
-		guard let metersPerPixel = mapView?.metersPerPixel() else {
+		guard let mapView = mapView else {
 			return
 		}
+		let left = convert(CGPoint(x: bounds.minX, y: bounds.minY), to: mapView)
+		let right = convert(CGPoint(x: bounds.maxX, y: bounds.minY), to: mapView)
+		let rulerLength = mapView.distance(from: left, to: right)
 
-		var width = Measurement(value: bounds.width * metersPerPixel, unit: UnitLength.meters)
+		var width = Measurement(value: rulerLength, unit: UnitLength.meters)
 		switch unitType {
 		case .metric:
 			if width.value >= 1000 {

--- a/src/iOS/CustomViews/RulerView.swift
+++ b/src/iOS/CustomViews/RulerView.swift
@@ -27,20 +27,31 @@ func roundToEvenValue(_ value: Double) -> Double {
 
 class RulerView: UIView {
 	private var shapeLayer: CAShapeLayer
-	private var metricTextLayer: CATextLayer
-	private var britishTextLayer: CATextLayer
+	private var textLayer: CATextLayer
+	private var unitType: UnitType {
+		didSet {
+			updateText()
+		}
+	}
+
 	var mapView: MapView? {
 		didSet {
 			mapView?.mapTransform.observe(by: self, callback: { self.updateText() })
 		}
 	}
 
+	enum UnitType: String {
+		case metric, imperial
+	}
+
 	required init?(coder: NSCoder) {
 		shapeLayer = CAShapeLayer()
-		metricTextLayer = CATextLayer()
-		britishTextLayer = CATextLayer()
+		textLayer = CATextLayer()
+		unitType = Locale.current.usesMetricSystem ? .metric : .imperial
 
 		super.init(coder: coder)
+		self.isUserInteractionEnabled = true
+
 		backgroundColor = nil
 
 		shapeLayer.lineWidth = 2
@@ -48,16 +59,19 @@ class RulerView: UIView {
 		shapeLayer.fillColor = nil
 
 		let font = UIFont.preferredFont(forTextStyle: .caption2)
-		metricTextLayer.font = font
-		britishTextLayer.font = font
-		metricTextLayer.fontSize = 12 // font.pointSize;
-		britishTextLayer.fontSize = 12 // font.pointSize;
-		metricTextLayer.foregroundColor = UIColor.black.cgColor
-		britishTextLayer.foregroundColor = UIColor.black.cgColor
-		metricTextLayer.alignmentMode = .center
-		britishTextLayer.alignmentMode = .center
-		metricTextLayer.contentsScale = UIScreen.main.scale
-		britishTextLayer.contentsScale = UIScreen.main.scale
+		let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .caption2)
+		let monospacedFontDescriptor = fontDescriptor.addingAttributes([
+			.featureSettings: [[
+				UIFontDescriptor.FeatureKey.featureIdentifier: kNumberSpacingType,
+				UIFontDescriptor.FeatureKey.typeIdentifier: kMonospacedNumbersSelector
+			]]
+		])
+		let monospacedFont = UIFont(descriptor: monospacedFontDescriptor, size: font.pointSize)
+		textLayer.font = monospacedFont
+		textLayer.fontSize = 12 // font.pointSize;
+		textLayer.foregroundColor = UIColor.black.cgColor
+		textLayer.alignmentMode = .center
+		textLayer.contentsScale = UIScreen.main.scale
 
 		layer.shadowColor = UIColor.white.cgColor
 		layer.shadowRadius = 0.0
@@ -66,12 +80,15 @@ class RulerView: UIView {
 		layer.shadowPath = CGPath(rect: bounds.insetBy(dx: -2, dy: -2), transform: nil)
 
 		shapeLayer.shadowOpacity = 0.0
-		metricTextLayer.shadowOpacity = 0.0
-		britishTextLayer.shadowOpacity = 0.0
+		textLayer.shadowOpacity = 0.0
 
 		layer.addSublayer(shapeLayer)
-		layer.addSublayer(metricTextLayer)
-		layer.addSublayer(britishTextLayer)
+		layer.addSublayer(textLayer)
+
+		let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(toggleUnitType))
+		addGestureRecognizer(tapGestureRecognizer)
+
+		NotificationCenter.default.addObserver(self, selector: #selector(localeDidChange), name: NSLocale.currentLocaleDidChangeNotification, object: nil)
 	}
 
 	override var frame: CGRect {
@@ -86,25 +103,19 @@ class RulerView: UIView {
 	}
 
 	override func layoutSubviews() {
-		var rc = bounds
+		let rc = bounds
 		if rc.size.width <= 1 || rc.size.height <= 1 {
 			return
 		}
 
 		let path = CGMutablePath()
-		path.move(to: CGPoint(x: rc.minX, y: rc.midY))
-		path.addLine(to: CGPoint(x: rc.maxX, y: rc.midY))
 		path.move(to: CGPoint(x: rc.minX, y: rc.minY))
 		path.addLine(to: CGPoint(x: rc.minX, y: rc.maxY))
-		path.move(to: CGPoint(x: rc.maxX, y: rc.minY))
 		path.addLine(to: CGPoint(x: rc.maxX, y: rc.maxY))
+		path.addLine(to: CGPoint(x: rc.maxX, y: rc.minY))
 		shapeLayer.path = path
 
-		rc.size.height = rc.height / 2
-		britishTextLayer.frame = rc
-
-		rc.origin.y = rc.origin.y + rc.height
-		metricTextLayer.frame = rc
+		textLayer.frame = rc
 	}
 
 	private func updateText() {
@@ -112,29 +123,43 @@ class RulerView: UIView {
 			return
 		}
 
-		var widthMetric = Measurement(value: bounds.width * metersPerPixel, unit: UnitLength.meters)
-		if widthMetric.value >= 1000 {
-			widthMetric = widthMetric.converted(to: .kilometers)
-		} else if widthMetric.value < 1.0 {
-			widthMetric = widthMetric.converted(to: .centimeters)
-		}
-
-		var widthBritish = widthMetric.converted(to: .feet)
-		if widthBritish.value >= 5280 {
-			widthBritish = widthBritish.converted(to: .miles)
-		} else if widthBritish.value < 1.0 {
-			widthBritish = widthBritish.converted(to: .inches)
+		var width = Measurement(value: bounds.width * metersPerPixel, unit: UnitLength.meters)
+		switch unitType {
+		case .metric:
+			if width.value >= 1000 {
+				width = width.converted(to: .kilometers)
+			} else if width.value < 1.0 {
+				width = width.converted(to: .centimeters)
+			}
+		case .imperial:
+			width = width.converted(to: .feet)
+			if width.value >= 5280 {
+				width = width.converted(to: .miles)
+			} else if width.value < 1.0 {
+				width = width.converted(to: .inches)
+			}
 		}
 
 		let formatter = MeasurementFormatter()
 		formatter.unitOptions = [.providedUnit]
 		formatter.numberFormatter = NumberFormatter()
 		formatter.numberFormatter.maximumSignificantDigits = 3
-		metricTextLayer.string = formatter.string(from: widthMetric)
-		britishTextLayer.string = formatter.string(from: widthBritish)
+		textLayer.string = formatter.string(from: width)
+	}
+
+	@objc private func toggleUnitType() {
+		unitType = (unitType == .metric) ? .imperial : .metric
+	}
+
+	@objc private func localeDidChange() {
+		unitType = Locale.current.usesMetricSystem ? .metric : .imperial
 	}
 
 	override func setNeedsLayout() {
 		super.setNeedsLayout()
+	}
+
+	deinit {
+		NotificationCenter.default.removeObserver(self)
 	}
 }

--- a/src/iOS/CustomViews/RulerView.swift
+++ b/src/iOS/CustomViews/RulerView.swift
@@ -146,6 +146,7 @@ class RulerView: UIView {
 		let formatter = MeasurementFormatter()
 		formatter.unitOptions = [.providedUnit]
 		formatter.numberFormatter = NumberFormatter()
+		formatter.numberFormatter.minimumSignificantDigits = 3
 		formatter.numberFormatter.maximumSignificantDigits = 3
 		textLayer.string = formatter.string(from: width)
 	}


### PR DESCRIPTION
Closes #726

The initial unit system is set from the user's system locale. pressing on the bar changes the unit (which in my opinion is a bad idea, it should be a setting because users are going to press it accidentally and then have no idea why it changed or how to change it back, just as you didn't know that clicking the scale bar on iD changes the units). changing your locale in system settings also changes the unit, regardless of what it was set to before.

I also changed it to use monospace numbers so that the "m" doesn't jitter around as much as you zoom. ~~it still jitters when you go between adding/removing the decimal point and more or less numbers.~~ and made it always use at least 3 digits.

~~I also removed the black line and left-aligned the text~~

<img width="277" alt="minimal" src="https://github.com/bryceco/GoMap/assets/5687998/8e2900a4-f115-4dd1-a6db-9de749540752">
