### PR TITLE
Remove the word "Enable" from options

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,18 @@ A number of assets used in the app come from other repositories, and should be p
 - Name Suggestion Index (https://github.com/osmlab/name-suggestion-index)
 - NSI brand imagery (pulled from Facebook/Twitter/Wikipedia)
 - StreetComplete quest filters (https://github.com/streetcomplete/StreetComplete)
-- WebLate translations (https://hosted.weblate.org/projects/go-map/app)
+- Weblate translations (https://hosted.weblate.org/projects/go-map/app)
 
-### How to update external assets
+### Updating external assets
 
-Starting from the `src` directory:
-- `(cd presets && ./update.sh)`				# fetches latest presets.json, etc. files and NSI
-- `(cd presets && ./getBrandIcons.py)`		# downloads images from various websites and converts them to png as necessary
-- `(cd presets && ./uploadBrandIcons.sh)`	# uploads imagery to gomaposm.com where they can be downloaded on demand at runtime (password required)
-- `(cd POI-Icons && ./update.sh)`			# fetches maki/temaki icons 
-- `(cd xliff && ./update.sh)`					# downloads latest translations from weblate (password required). This step is very noisy and produces many pages of warnings that can be ignored.
+```sh
+cd src
+(cd presets && ./update.sh)			# fetches latest presets.json, etc. files and NSI
+(cd presets && ./getBrandIcons.py)		# downloads images from various websites and converts them to PNG as necessary
+(cd presets && ./uploadBrandIcons.sh)	# uploads imagery to gomaposm.com where they can be downloaded on demand at runtime (password required)
+(cd POI-Icons && ./update.sh)			# fetches Maki/Temaki icons 
+(cd xliff && ./update.sh)				# downloads latest translations from Weblate (API token required). The output is very noisy and can be ignored
+```
 
 ## Continuous integration
 

--- a/src/iOS/DisplaySettings/Base.lproj/Display.storyboard
+++ b/src/iOS/DisplaySettings/Base.lproj/Display.storyboard
@@ -307,11 +307,11 @@
                                 </cells>
                             </tableViewSection>
                             <tableViewSection headerTitle="Discard &amp; Refresh" id="SNa-W1-wga">
-                                <mutableString key="footerTitle">Clear the OSM data cache if the application state becomes out of sync with the OSM server. This may occur if someone else changes data you are editing, or if one of your uploads fails midway through preventing you from uploading additional data. 
+                                <string key="footerTitle">Clear the OSM data cache if the application state becomes out of sync with the OSM server. This may occur if someone else changes data you are editing, or if one of your uploads fails midway through preventing you from uploading additional data. 
 
 Warning: Clearing the OSM cache will cause you to lose any changes that have not yet been uploaded.
 
-Clear the Basemap or Overlay tile caches  to download the latest tiles that reflect changes you've previously submitted. Your changes may take up to 24 hours to be processed.</mutableString>
+Clear the Basemap or Overlay tile caches  to download the latest tiles that reflect changes you've previously submitted. Your changes may take up to 24 hours to be processed.</string>
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="ClearCacheCell" id="u2V-UV-qvY" customClass="ClearCacheCell" customModule="Go_Map__" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="191" width="414" height="44"/>
@@ -1438,8 +1438,8 @@ Clear the Basemap or Overlay tile caches  to download the latest tiles that refl
                                             <rect key="frame" x="0.0" y="0.0" width="383.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable Filters" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LxX-tl-ZLH">
-                                                    <rect key="frame" x="15" y="11.5" width="107" height="21"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filters" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LxX-tl-ZLH">
+                                                    <rect key="frame" x="15" y="11.5" width="49.5" height="21"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -1509,8 +1509,8 @@ Clear the Basemap or Overlay tile caches  to download the latest tiles that refl
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable Rotation" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VUR-wT-knn">
-                                                    <rect key="frame" x="15" y="11.5" width="124.5" height="21"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Map Rotation" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VUR-wT-knn">
+                                                    <rect key="frame" x="15" y="11.5" width="105.5" height="21"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -1557,7 +1557,7 @@ Clear the Basemap or Overlay tile caches  to download the latest tiles that refl
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="qfn-yi-XU8" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-4116" y="558"/>
+            <point key="canvasLocation" x="-4117.391304347826" y="557.8125"/>
         </scene>
         <!--QuestChooser-->
         <scene sceneID="vAz-WB-XzV">

--- a/src/iOS/DisplaySettings/Base.lproj/Display.storyboard
+++ b/src/iOS/DisplaySettings/Base.lproj/Display.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -1438,8 +1438,8 @@ Clear the Basemap or Overlay tile caches  to download the latest tiles that refl
                                             <rect key="frame" x="0.0" y="0.0" width="383.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filters" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LxX-tl-ZLH">
-                                                    <rect key="frame" x="15" y="11.5" width="49.5" height="21"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Object Filters" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LxX-tl-ZLH">
+                                                    <rect key="frame" x="15" y="11.5" width="106.5" height="21"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>


### PR DESCRIPTION
Enable Filters → Filters

Enable Rotation → Map Rotation

It doesn't make sense to have the word "Enable" next to an on/off switch. The switch already implies that the given thing is enabled/disabled.