### PR TITLE
Make tunnels slightly transparent

### DIFF
--- a/src/Shared/EditorLayer/EditorMapLayer.swift
+++ b/src/Shared/EditorLayer/EditorMapLayer.swift
@@ -17,7 +17,7 @@ private let SINGLE_SIDED_WALLS = true
 
 // drawing options
 private let DEFAULT_LINECAP = CAShapeLayerLineCap.butt
-private let DEFAULT_LINEJOIN = CAShapeLayerLineJoin.miter
+private let DEFAULT_LINEJOIN = CAShapeLayerLineJoin.round
 private let MinIconSizeInPixels: CGFloat = 24.0
 private let Pixels_Per_Character: CGFloat = 8.0
 private let NodeHighlightRadius: CGFloat = 6.0

--- a/src/Shared/EditorLayer/RenderInfo.swift
+++ b/src/Shared/EditorLayer/RenderInfo.swift
@@ -34,10 +34,12 @@ final class RenderInfo {
 	var key = ""
 	var value: String?
 	var lineColor: UIColor?
+	var lineOpacity: CGFloat = 1.0
 	var lineWidth: CGFloat = 0.0
 	var lineCap: CAShapeLayerLineCap
 	var lineDashPattern: [NSNumber]?
 	var casingColor: UIColor?
+	var casingOpacity: CGFloat = 1.0
 	var casingWidth: CGFloat
 	var casingCap: CAShapeLayerLineCap
 	var casingDashPattern: [NSNumber]?
@@ -51,10 +53,12 @@ final class RenderInfo {
 	func isDefault() -> Bool {
 		// These values should match the init() defaults
 		return lineColor == UIColor.white
+			&& lineOpacity == 1.0
 			&& lineWidth == 1.0
 			&& lineCap == .round
 			&& lineDashPattern == nil
 			&& casingColor == nil
+			&& casingOpacity == 1.0
 			&& casingWidth == 0.0
 			&& casingCap == .butt
 			&& casingDashPattern == nil
@@ -65,10 +69,12 @@ final class RenderInfo {
 		key: String = "",
 		value: String? = nil,
 		lineColor: UIColor? = .white,
+		lineOpacity: CGFloat = 1.0,
 		lineWidth: CGFloat = 1.0,
 		lineCap: CAShapeLayerLineCap = .round,
 		lineDashPattern: [CGFloat]? = nil,
 		casingColor: UIColor? = nil,
+		casingOpacity: CGFloat = 1.0,
 		casingWidth: CGFloat = 0.0,
 		casingCap: CAShapeLayerLineCap = .butt,
 		casingDashPattern: [CGFloat]? = nil,
@@ -115,6 +121,14 @@ final class RenderInfo {
 			renderInfo.casingWidth = max(renderInfo.casingWidth, renderInfo.lineWidth + 4)
 		} else if renderInfo.lineWidth >= renderInfo.casingWidth {
 			renderInfo.casingWidth = renderInfo.lineWidth + 1
+		}
+		
+		// combine opacity with color's alpha channel
+		if let color = renderInfo.lineColor {
+			renderInfo.lineColor = color.withAlphaComponent(color.cgColor.alpha * renderInfo.lineOpacity)
+		}
+		if let color = renderInfo.casingColor {
+			renderInfo.casingColor = color.withAlphaComponent(color.cgColor.alpha * renderInfo.casingOpacity)
 		}
 
 		// check if it is an address point

--- a/src/Shared/EditorLayer/iD/Theme.swift
+++ b/src/Shared/EditorLayer/iD/Theme.swift
@@ -194,7 +194,9 @@ extension RenderInfo {
 		if (primary == "highway" && primaryValue == "path") || (primary == "highway" && primaryValue == "footway") ||
 			(primary == "highway" && primaryValue == "cycleway") ||
 			(primary == "highway" && primaryValue == "bridleway") ||
-			(primary == "highway" && primaryValue == "corridor") || (primary == "highway" && primaryValue == "steps")
+			(primary == "highway" && primaryValue == "corridor") ||
+			(primary == "highway" && primaryValue == "ladder") ||
+			(primary == "highway" && primaryValue == "steps")
 		{
 			r.lineWidth = 1.5
 			r.casingWidth = 2.5
@@ -277,7 +279,7 @@ extension RenderInfo {
 		if (primary == "leisure" && primaryValue == "track") || tags["leisure"] == "track" {
 			r.lineColor = DynamicColor(red: 0.898, green: 0.722, blue: 0.169, alpha: 1.0)
 		}
-		if primary == "highway" && primaryValue == "steps" {
+		if (primary == "highway" && primaryValue == "steps") || (primary == "highway" && primaryValue == "ladder") {
 			r.lineColor = DynamicColor(red: 0.506, green: 0.824, blue: 0.361, alpha: 1.0)
 			r.lineCap = .butt
 			r.lineDashPattern = [1.5, 1.5]
@@ -331,9 +333,15 @@ extension RenderInfo {
 			r.lineWidth = 2.5
 			r.casingWidth = 3.5
 		}
+		if (primary == "waterway" && primaryValue == "river") || (primary == "waterway" && primaryValue == "flowline") {
+			r.casingWidth = 5.0
+		}
 		if primary == "waterway" && primaryValue == "river" {
 			r.lineWidth = 4.0
-			r.casingWidth = 5.0
+		}
+		if primary == "waterway" && primaryValue == "flowline" {
+			r.lineOpacity = 0.5
+			r.lineWidth = 4.0
 		}
 		if primary == "waterway" && primaryValue == "ditch" {
 			r.lineColor = DynamicColor(red: 0.2, green: 0.6, blue: 0.667, alpha: 1.0)
@@ -416,27 +424,20 @@ extension RenderInfo {
 		}
 		if has(tags, "bridge") {
 			r.casingColor = DynamicColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0)
-			r.casingOpacity = 0.3
+			r.casingOpacity = 0.6
 			r.casingWidth = 8.0
 			r.casingCap = .butt
 			r.casingDashPattern = nil
 		}
 		if has(tags, "tunnel") || (tags["location"] == "underground") || (tags["location"] == "underwater") {
-			r.lineOpacity = 0.15
-		}
-		if has(tags, "tunnel") || (tags["location"] == "underground") {
-			r.casingOpacity = 0.25
+			r.lineOpacity = 0.3
+			r.casingOpacity = 0.5
 			r.casingCap = .butt
 			r.casingDashPattern = nil
 		}
-		if tags["location"] == "underwater" {
-			r.lineOpacity = 0.25
-			r.lineCap = .butt
-			r.lineDashPattern = nil
-		}
 		if has(tags, "embankment") || has(tags, "cutting") {
 			r.casingColor = DynamicColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0)
-			r.casingOpacity = 0.25
+			r.casingOpacity = 0.5
 			r.casingWidth = 11.0
 			r.casingCap = .butt
 			r.casingDashPattern = [1, 2]
@@ -565,6 +566,7 @@ extension RenderInfo {
 			((primary == "highway" && primaryValue == "service") && has(tags, "bridge")) ||
 			((primary == "highway" && primaryValue == "track") && has(tags, "bridge")) ||
 			((primary == "highway" && primaryValue == "steps") && has(tags, "bridge")) ||
+			((primary == "highway" && primaryValue == "ladder") && has(tags, "bridge")) ||
 			((primary == "highway" && primaryValue == "footway") && has(tags, "bridge")) ||
 			((primary == "highway" && primaryValue == "cycleway") && has(tags, "bridge")) ||
 			((primary == "highway" && primaryValue == "bridleway") && has(tags, "bridge"))
@@ -602,7 +604,9 @@ extension RenderInfo {
 			(
 				primary == "highway" && tags["construction"] == "bridleway" && status != nil && status ==
 					"construction") ||
-			(primary == "highway" && tags["construction"] == "steps" && status != nil && status == "construction")
+			(primary == "highway" && tags["construction"] == "corridor" && status != nil && status == "construction") ||
+			(primary == "highway" && tags["construction"] == "steps" && status != nil && status == "construction") ||
+			(primary == "highway" && tags["construction"] == "ladder" && status != nil && status == "construction")
 		{
 			r.lineWidth = 2.0
 			r.lineCap = .butt
@@ -615,7 +619,8 @@ extension RenderInfo {
 			(primary == "highway" && tags["proposed"] == "footway" && status != nil && status == "proposed") ||
 			(primary == "highway" && tags["proposed"] == "cycleway" && status != nil && status == "proposed") ||
 			(primary == "highway" && tags["proposed"] == "bridleway" && status != nil && status == "proposed") ||
-			(primary == "highway" && tags["proposed"] == "steps" && status != nil && status == "proposed")
+			(primary == "highway" && tags["proposed"] == "steps" && status != nil && status == "proposed") ||
+			(primary == "highway" && tags["proposed"] == "ladder" && status != nil && status == "proposed")
 		{
 			r.lineWidth = 1.5
 			r.casingWidth = 2.25
@@ -630,6 +635,8 @@ extension RenderInfo {
 				status ==
 				"proposed") ||
 			(primary == "highway" && has(tags, "bridge") && tags["proposed"] == "steps" && status != nil && status ==
+				"proposed") ||
+			(primary == "highway" && has(tags, "bridge") && tags["proposed"] == "ladder" && status != nil && status ==
 				"proposed")
 		{
 			r.casingWidth = 5.0

--- a/src/Shared/EditorLayer/iD/Theme.swift
+++ b/src/Shared/EditorLayer/iD/Theme.swift
@@ -416,20 +416,27 @@ extension RenderInfo {
 		}
 		if has(tags, "bridge") {
 			r.casingColor = DynamicColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0)
+			r.casingOpacity = 0.3
 			r.casingWidth = 8.0
 			r.casingCap = .butt
 			r.casingDashPattern = nil
 		}
+		if has(tags, "tunnel") || (tags["location"] == "underground") || (tags["location"] == "underwater") {
+			r.lineOpacity = 0.15
+		}
 		if has(tags, "tunnel") || (tags["location"] == "underground") {
+			r.casingOpacity = 0.25
 			r.casingCap = .butt
 			r.casingDashPattern = nil
 		}
 		if tags["location"] == "underwater" {
+			r.lineOpacity = 0.25
 			r.lineCap = .butt
 			r.lineDashPattern = nil
 		}
 		if has(tags, "embankment") || has(tags, "cutting") {
 			r.casingColor = DynamicColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0)
+			r.casingOpacity = 0.25
 			r.casingWidth = 11.0
 			r.casingCap = .butt
 			r.casingDashPattern = [1, 2]

--- a/src/Shared/EditorLayer/iD/extract.py
+++ b/src/Shared/EditorLayer/iD/extract.py
@@ -554,7 +554,7 @@ enum LineCapStyle {
 }
 
 class RenderInfo {
-	var value: String?
+    var value: String?
     var lineColor: DynamicColor?
     var lineOpacity: CGFloat = 1.0
     var lineWidth: CGFloat = 0.0
@@ -565,12 +565,12 @@ class RenderInfo {
     var casingWidth: CGFloat = 0.0
     var casingCap: LineCapStyle = .butt
     var casingDashPattern: [NSNumber]?
-	var areaColor: DynamicColor?
+    var areaColor: DynamicColor?
 }
 
 func has(_ tags: [String: String], _ key: String) -> Bool {
-	let value = tags[key]
-	return value != nil && value != "no"
+    let value = tags[key]
+    return value != nil && value != "no"
 }
 """
 

--- a/src/Shared/EditorLayer/iD/extract.py
+++ b/src/Shared/EditorLayer/iD/extract.py
@@ -348,7 +348,7 @@ for file_path in sorted(css_files):
             key, value = l.split(":", 1)
             value = value.replace("!important", "").strip()
             if key not in css_keys:
-                err("Error, key not in css_keys:", key)
+                err("Error, key not in css_keys:", key, value)
                 continue
 
             if key == "stroke":


### PR DESCRIPTION
I updated extract.py to extract [stroke-opacity values](https://github.com/openstreetmap/iD/blob/14d76e4445512094d68580964c5abf08ed9f9a51/css/50_misc.css#L350) from the css and re-ran it on the latest commit to iD to update the theme.

I also changed `lineJoin` to `.round` to match iD.

left is `highway=path`, right is `highway=path` & `tunnel=yes`:

![8499613B-1DF5-49C9-9D18-55AD48C183D9](https://github.com/user-attachments/assets/5332b9f3-1309-4181-a7cc-05fff63bbdfa)

iD for comparison:

<img width="353" alt="Screenshot 2025-01-28 at 15 12 18" src="https://github.com/user-attachments/assets/a018bdaa-c37c-4226-ba9e-f17d094fa916" />
