### PR TITLE
Fix Live Activity image jumping by setting a fixed frame

### DIFF
--- a/src/iOS/GpxWidget/GpxWidgetLiveActivity.swift
+++ b/src/iOS/GpxWidget/GpxWidgetLiveActivity.swift
@@ -147,7 +147,8 @@ struct GpxWidgetLiveActivity: Widget {
 			} minimal: {
 				Image("AppIconTransparent")
 					.resizable()
-					.aspectRatio(contentMode: .fit)
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 24, height: 24)
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes an issue where the Live Activity image appeared to “slide in” during updates.
By enforcing a fixed frame for the image, the layout remains stable across re-renders.

https://github.com/user-attachments/assets/96d4cbb1-11d9-4a52-a513-e5b737e73116

