### PR TITLE
Map style: Separate styles for `highway=steps|ladder`

### DIFF
--- a/src/Shared/EditorLayer/iD/Theme.swift
+++ b/src/Shared/EditorLayer/iD/Theme.swift
@@ -279,7 +279,15 @@ extension RenderInfo {
 		if (primary == "leisure" && primaryValue == "track") || tags["leisure"] == "track" {
 			r.lineColor = DynamicColor(red: 0.898, green: 0.722, blue: 0.169, alpha: 1.0)
 		}
-		if (primary == "highway" && primaryValue == "steps") || (primary == "highway" && primaryValue == "ladder") {
+		if primary == "highway" && primaryValue == "ladder" {
+			r.lineColor = DynamicColor(red: 0.435, green: 0.122, blue: 0.122, alpha: 1.0)
+			r.lineCap = .butt
+			r.lineDashPattern = [1.5, 1.5]
+			r.casingColor = DynamicColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+			r.casingCap = .round
+			r.casingDashPattern = nil
+		}
+		if primary == "highway" && primaryValue == "steps" {
 			r.lineColor = DynamicColor(red: 0.506, green: 0.824, blue: 0.361, alpha: 1.0)
 			r.lineCap = .butt
 			r.lineDashPattern = [1.5, 1.5]


### PR DESCRIPTION
This applies the changes from https://github.com/openstreetmap/iD/pull/11804 to GoMap.

The story behind it is in https://github.com/openstreetmap/iD/issues/11799
Steps are sometimes misstagged as ladders. This changes the style so one can see the difference more easily. It makes them a red color `#6f1f1f` that iD uses for `via_ferrata` to signal that those are highways but "dangerous" ways.

---

Disclaimer: I did not run this code – I don't have a dev setup for GoMap at this time.