### PR TITLE
Preserve POI type search text until attribute editor closes

### DIFF
--- a/src/iOS/POI/POIFeaturePickerViewController.swift
+++ b/src/iOS/POI/POIFeaturePickerViewController.swift
@@ -27,14 +27,6 @@ private var mostRecentArray: [PresetFeature] = []
 private var mostRecentMaximum = 0
 
 class POIFeaturePickerViewController: UITableViewController, UISearchBarDelegate {
-	/// Persists the type-picker search query while the POI editor stays open; cleared when that editor is dismissed.
-	private static var preservedFeatureTypeSearchText: String?
-
-	/// Called when the POI attribute editor modal is dismissed (save, cancel, swipe, etc.).
-	class func clearPreservedFeatureTypeSearchText() {
-		preservedFeatureTypeSearchText = nil
-	}
-
 	private var featureList: [PresetFeatureOrCategory] = []
 	private var searchArray: [PresetFeature] = []
 	@IBOutlet var searchBar: UISearchBar!
@@ -100,7 +92,10 @@ class POIFeaturePickerViewController: UITableViewController, UISearchBarDelegate
 	}
 
 	private func restorePreservedSearchIfNeeded() {
-		guard let preserved = Self.preservedFeatureTypeSearchText else { return }
+		guard let tabController = tabBarController as? POITabBarController,
+		      let preserved = tabController.preservedFeatureTypeSearchText,
+		      !preserved.isEmpty
+		else { return }
 		if searchBar.text != preserved {
 			searchBar.text = preserved
 		}
@@ -277,7 +272,9 @@ class POIFeaturePickerViewController: UITableViewController, UISearchBarDelegate
 	}
 
 	func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-		Self.preservedFeatureTypeSearchText = searchText
+		if let tabController = tabBarController as? POITabBarController {
+			tabController.preservedFeatureTypeSearchText = searchText.isEmpty ? nil : searchText
+		}
 		refreshSearchResults(for: searchText)
 	}
 

--- a/src/iOS/POI/POIFeaturePickerViewController.swift
+++ b/src/iOS/POI/POIFeaturePickerViewController.swift
@@ -27,6 +27,14 @@ private var mostRecentArray: [PresetFeature] = []
 private var mostRecentMaximum = 0
 
 class POIFeaturePickerViewController: UITableViewController, UISearchBarDelegate {
+	/// Persists the type-picker search query while the POI editor stays open; cleared when that editor is dismissed.
+	private static var preservedFeatureTypeSearchText: String?
+
+	/// Called when the POI attribute editor modal is dismissed (save, cancel, swipe, etc.).
+	class func clearPreservedFeatureTypeSearchText() {
+		preservedFeatureTypeSearchText = nil
+	}
+
 	private var featureList: [PresetFeatureOrCategory] = []
 	private var searchArray: [PresetFeature] = []
 	@IBOutlet var searchBar: UISearchBar!
@@ -69,6 +77,34 @@ class POIFeaturePickerViewController: UITableViewController, UISearchBarDelegate
 			isTopLevel = true
 			featureList = PresetsDatabase.shared.featuresAndCategoriesForGeometry(geometry)
 		}
+	}
+
+	override func viewWillAppear(_ animated: Bool) {
+		super.viewWillAppear(animated)
+		restorePreservedSearchIfNeeded()
+	}
+
+	/// Re-applies the in-memory search query and reloads the table (used when restoring state and from `UISearchBarDelegate`).
+	private func refreshSearchResults(for searchText: String) {
+		if searchText.isEmpty {
+			searchArray = []
+		} else {
+			let geometry = currentSelectionGeometry()
+			searchArray = PresetsDatabase.shared.featuresInCategory(
+				parentCategory,
+				matching: searchText,
+				geometry: geometry,
+				location: AppDelegate.shared.mainView.currentRegion)
+		}
+		tableView.reloadData()
+	}
+
+	private func restorePreservedSearchIfNeeded() {
+		guard let preserved = Self.preservedFeatureTypeSearchText else { return }
+		if searchBar.text != preserved {
+			searchBar.text = preserved
+		}
+		refreshSearchResults(for: preserved)
 	}
 
 	override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -241,19 +277,8 @@ class POIFeaturePickerViewController: UITableViewController, UISearchBarDelegate
 	}
 
 	func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-		if searchText.count == 0 {
-			// no search
-			searchArray = []
-		} else {
-			// searching
-			let geometry = currentSelectionGeometry()
-			searchArray = PresetsDatabase.shared.featuresInCategory(
-				parentCategory,
-				matching: searchText,
-				geometry: geometry,
-				location: AppDelegate.shared.mainView.currentRegion)
-		}
-		tableView.reloadData()
+		Self.preservedFeatureTypeSearchText = searchText
+		refreshSearchResults(for: searchText)
 	}
 
 	@IBAction func configure(_ sender: Any) {

--- a/src/iOS/POI/POITabBarController.swift
+++ b/src/iOS/POI/POITabBarController.swift
@@ -46,6 +46,13 @@ class POITabBarController: UITabBarController {
 		}
 	}
 
+	override func viewWillDisappear(_ animated: Bool) {
+		super.viewWillDisappear(animated)
+		if isBeingDismissed || isMovingFromParent {
+			POIFeaturePickerViewController.clearPreservedFeatureTypeSearchText()
+		}
+	}
+
 	override func viewDidAppear(_ animated: Bool) {
 		super.viewDidAppear(animated)
 

--- a/src/iOS/POI/POITabBarController.swift
+++ b/src/iOS/POI/POITabBarController.swift
@@ -11,6 +11,8 @@ class POITabBarController: UITabBarController {
 	var keyValueDict = [String: String]()
 	var relationList: [OsmRelation] = []
 	var selection: OsmBaseObject?
+	/// Type-picker search query kept for the lifetime of this editor session.
+	var preservedFeatureTypeSearchText: String?
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
@@ -49,7 +51,7 @@ class POITabBarController: UITabBarController {
 	override func viewWillDisappear(_ animated: Bool) {
 		super.viewWillDisappear(animated)
 		if isBeingDismissed || isMovingFromParent {
-			POIFeaturePickerViewController.clearPreservedFeatureTypeSearchText()
+			preservedFeatureTypeSearchText = nil
 		}
 	}
 


### PR DESCRIPTION
## Summary

When choosing a feature type from search, returning to the tags screen after a mistaken pick previously left the type picker with an empty search field. The search query is now kept for the whole time the POI attribute editor (tab bar modal) stays open, and is cleared only when that modal is dismissed (save, cancel, interactive dismiss, etc.).

## Implementation by Cursor

- `POIFeaturePickerViewController`: store the current search string in a private static while the user edits; restore it in `viewWillAppear` and reuse a single `refreshSearchResults` helper from `searchBar(_:textDidChange:)`.
- `POITabBarController`: clear the stored string in `viewWillDisappear` when the controller is being dismissed or removed from its parent.

The system search field clear control still clears the text through the existing delegate path.

## Testing by me

Manually tested with Xcode Simulator:

https://github.com/user-attachments/assets/4dbfa5b1-5c51-41b2-93f7-6b8123d1de82