### PR TITLE
Attributes tab: Done dismisses POI editor when tags unchanged

### DIFF
--- a/src/iOS/POI/POIAllTagsViewController.swift
+++ b/src/iOS/POI/POIAllTagsViewController.swift
@@ -171,10 +171,7 @@ class POIAllTagsViewController: UITableViewController, POIFeaturePickerDelegate,
 		tags.setWithoutSorting(list)
 		tableView.reloadData()
 
-		saveButton.isEnabled = tabController.isTagDictChanged()
-		if #available(iOS 13.0, *) {
-			tabBarController?.isModalInPresentation = saveButton.isEnabled
-		}
+		tabController.updateSaveButton(saveButton, hasUnsavedTagChanges: tabController.isTagDictChanged())
 
 		return nextRow
 	}
@@ -390,10 +387,9 @@ class POIAllTagsViewController: UITableViewController, POIFeaturePickerDelegate,
 		kvCell.isSet.backgroundColor = kv.k == "" || kv.v == "" ? nil : UIColor.systemBlue
 
 		let tabController = tabBarController as! POITabBarController
-		saveButton.isEnabled = tabController.isTagDictChanged(tags.keyValueDictionary())
-		if #available(iOS 13.0, *) {
-			tabBarController?.isModalInPresentation = saveButton.isEnabled
-		}
+		tabController.updateSaveButton(
+			saveButton,
+			hasUnsavedTagChanges: tabController.isTagDictChanged(tags.keyValueDictionary()))
 	}
 
 	func keyValueEditingEnded(for kvCell: KeyValueTableCell) {
@@ -525,10 +521,7 @@ class POIAllTagsViewController: UITableViewController, POIFeaturePickerDelegate,
 				tableView.deleteRows(at: [indexPath], with: .fade)
 			}
 
-			saveButton.isEnabled = tabController.isTagDictChanged()
-			if #available(iOS 13.0, *) {
-				tabBarController?.isModalInPresentation = saveButton.isEnabled
-			}
+			tabController.updateSaveButton(saveButton, hasUnsavedTagChanges: tabController.isTagDictChanged())
 		} else if editingStyle == .insert {
 			// Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
 		}
@@ -540,11 +533,15 @@ class POIAllTagsViewController: UITableViewController, POIFeaturePickerDelegate,
 	}
 
 	@IBAction func done(_ sender: Any) {
-		dismiss(animated: true)
 		saveState()
+		dismiss(animated: true)
 
-		let tabController = tabBarController as? POITabBarController
-		tabController?.commitChanges()
+		guard let tabController = tabBarController as? POITabBarController,
+		      tabController.isTagDictChanged()
+		else {
+			return
+		}
+		tabController.commitChanges()
 	}
 
 	override func shouldPerformSegue(withIdentifier identifier: String, sender: Any?) -> Bool {

--- a/src/iOS/POI/POIAttributesViewController.swift
+++ b/src/iOS/POI/POIAttributesViewController.swift
@@ -45,8 +45,9 @@ class POIAttributesViewController: UITableViewController {
 	override func viewWillAppear(_ animated: Bool) {
 		super.viewWillAppear(animated)
 
-		let tabController = tabBarController as? POITabBarController
-		saveButton.isEnabled = tabController?.isTagDictChanged() ?? false
+		if let tabController = tabBarController as? POITabBarController {
+			tabController.updateSaveButton(saveButton, hasUnsavedTagChanges: tabController.isTagDictChanged())
+		}
 	}
 
 	override func numberOfSections(in tableView: UITableView) -> Int {
@@ -294,8 +295,11 @@ class POIAttributesViewController: UITableViewController {
 	@IBAction func done(_ sender: Any) {
 		dismiss(animated: true)
 
-		if let tabController = tabBarController as? POITabBarController {
-			tabController.commitChanges()
+		guard let tabController = tabBarController as? POITabBarController,
+		      tabController.isTagDictChanged()
+		else {
+			return
 		}
+		tabController.commitChanges()
 	}
 }

--- a/src/iOS/POI/POICommonTagsViewController.swift
+++ b/src/iOS/POI/POICommonTagsViewController.swift
@@ -135,10 +135,7 @@ class POICommonTagsViewController: UITableViewController, UITextFieldDelegate, U
 			tabController.keyValueDict.removeValue(forKey: key)
 		}
 
-		saveButton.isEnabled = tabController.isTagDictChanged()
-		if #available(iOS 13.0, *) {
-			tabController.isModalInPresentation = saveButton.isEnabled
-		}
+		tabController.updateSaveButton(saveButton, hasUnsavedTagChanges: tabController.isTagDictChanged())
 	}
 
 	func updateTagDict(withValue value: String, forKey key: String) {
@@ -153,10 +150,7 @@ class POICommonTagsViewController: UITableViewController, UITextFieldDelegate, U
 	func updatePresets() {
 		let tabController = tabBarController as! POITabBarController
 
-		saveButton.isEnabled = tabController.isTagDictChanged()
-		if #available(iOS 13.0, *) {
-			tabController.isModalInPresentation = saveButton.isEnabled
-		}
+		tabController.updateSaveButton(saveButton, hasUnsavedTagChanges: tabController.isTagDictChanged())
 
 		if drillDownGroup == nil {
 			let dict = tabController.keyValueDict
@@ -604,8 +598,12 @@ class POICommonTagsViewController: UITableViewController, UITextFieldDelegate, U
 		resignAll()
 		dismiss(animated: true)
 
-		let tabController = tabBarController as? POITabBarController
-		tabController?.commitChanges()
+		guard let tabController = tabBarController as? POITabBarController,
+		      tabController.isTagDictChanged()
+		else {
+			return
+		}
+		tabController.commitChanges()
 	}
 
 	// MARK: - Table view delegate
@@ -687,9 +685,8 @@ class POICommonTagsViewController: UITableViewController, UITextFieldDelegate, U
 	}
 
 	@IBAction func textFieldChanged(_ textField: UITextField) {
-		saveButton.isEnabled = true
-		if #available(iOS 13.0, *) {
-			tabBarController?.isModalInPresentation = saveButton.isEnabled
+		if let tabController = tabBarController as? POITabBarController {
+			tabController.updateSaveButton(saveButton, hasUnsavedTagChanges: true)
 		}
 		if let cell: UITableViewCell = textField.superviewOfType() {
 			switch cell {
@@ -748,9 +745,8 @@ class POICommonTagsViewController: UITableViewController, UITextFieldDelegate, U
 	}
 
 	func textViewDidChange(_ textView: UITextView) {
-		saveButton.isEnabled = true
-		if #available(iOS 13.0, *) {
-			tabBarController?.isModalInPresentation = saveButton.isEnabled
+		if let tabController = tabBarController as? POITabBarController {
+			tabController.updateSaveButton(saveButton, hasUnsavedTagChanges: true)
 		}
 
 		// This resizes the cell to be appropriate for the content

--- a/src/iOS/POI/POITabBarController.swift
+++ b/src/iOS/POI/POITabBarController.swift
@@ -123,6 +123,21 @@ class POITabBarController: UITabBarController {
 		return isTagDictChanged(keyValueDict)
 	}
 
+	/// Keeps Done tappable (so it can dismiss with no edits) while tint reflects unsaved tag changes.
+	func updateSaveButton(_ saveButton: UIBarButtonItem, hasUnsavedTagChanges: Bool) {
+		saveButton.isEnabled = true
+		if hasUnsavedTagChanges {
+			saveButton.tintColor = nil
+		} else if #available(iOS 13.0, *) {
+			saveButton.tintColor = .tertiaryLabel
+		} else {
+			saveButton.tintColor = .lightGray
+		}
+		if #available(iOS 13.0, *) {
+			isModalInPresentation = hasUnsavedTagChanges
+		}
+	}
+
 	override func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
 		guard
 			let tabIndex = tabBar.items?.firstIndex(of: item),


### PR DESCRIPTION
## Problem

On POI editor tabs (**Common Tags**, **All Tags**, **Attributes**), the navigation **Done** (checkmark) was disabled when tags were unchanged (`saveButton.isEnabled = false`). A disabled bar button does not run `done(_:)`, so the checkmark could highlight but the sheet stayed open. With edits, Done was enabled (blue) and dismissed + saved as expected.

**Expected:** Gray checkmark when unchanged, but tap still **dismisses** without saving. Blue checkmark when there are edits: **save** and dismiss.

Why: This allows users to aways close the panel with the top right button which is easer to remember and easer to reach. Also  when nothing changed, using "save changes" is OK because it changes nothing…

## Implementation notes (by Cursor)

**Root cause:** `UIBarButtonItem.isEnabled = false` blocks the action selector.

**Fix:**
- Added `POITabBarController.updateSaveButton(_:hasUnsavedTagChanges:)` — Done stays **enabled** (tappable); **tint** is gray (`.tertiaryLabel`) when unchanged, default accent when changed; `isModalInPresentation` still tracks unsaved changes.
- **`done(_:)`** on Common Tags, All Tags, and Attributes: always `dismiss`, call `commitChanges()` only when `isTagDictChanged()`.
- Replaced prior `saveButton.isEnabled = isTagDictChanged()` call sites in those controllers with `updateSaveButton`.

**Note:** New objects hide the Attributes tab; the behavior you see on “tags panel” is **Common Tags** (first tab).

**Automated testing:** Not covered by XCTest in this PR.

## Testing notes (@tordans)

1. **New node** → Common Tags (default) → gray checkmark → tap → sheet **closes**, no tags written.
2. **Existing node**, no edits → same.
3. Edit a tag → checkmark **blue** → tap → sheet closes, tags **saved**.
4. **Attributes** tab (existing object only): unchanged → gray, dismiss only; changed (from another tab) → blue, dismiss + commit.
5. **Cancel** still dismisses without commit.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>


https://github.com/user-attachments/assets/358268f7-6df4-4083-875f-0394cdf26f0e



</td><td>


https://github.com/user-attachments/assets/9e29f462-c74d-495c-9a4f-0a8ad7c17d7f



</td></tr>
</table>