### PR TITLE
Directional nodes: map Rotate updates `direction` / `camera:direction`

### DIFF
--- a/src/Shared/EditorLayer/EditorMapLayer+Edit.swift
+++ b/src/Shared/EditorLayer/EditorMapLayer+Edit.swift
@@ -458,6 +458,54 @@ extension EditorMapLayer {
 		mapData.endUndoGrouping()
 	}
 
+	// MARK: Rotate direction tag
+
+	func rotateDirectionBegin() {
+		guard let node = selectedNode,
+		      let tagKey = node.technicalDirectionTagKey,
+		      let bearing = node.direction?.location
+		else { return }
+		mapData.beginUndoGrouping()
+		dragState.didMove = false
+		directionRotateTagKey = tagKey
+		directionRotateInitialBearing = bearing
+	}
+
+	func rotateDirectionContinue(delta: CGFloat) {
+		guard let node = selectedNode,
+		      let tagKey = directionRotateTagKey,
+		      let initialBearing = directionRotateInitialBearing
+		else { return }
+
+		if dragState.didMove {
+			mapData.endUndoGrouping()
+			silentUndo = true
+			mapData.undo()
+			silentUndo = false
+			mapData.beginUndoGrouping()
+		}
+		dragState.didMove = true
+
+		let deltaDegrees = Int(round(Double(-delta) * 180 / .pi))
+		let bearing = ((initialBearing + deltaDegrees) % 360 + 360) % 360
+		guard let value = node.directionTagValue(forBearingDegrees: bearing) else { return }
+		var tags = node.tags
+		tags[tagKey] = value
+		mapData.setTags(tags, for: node)
+		setNeedsLayout()
+		owner.didUpdateObject()
+	}
+
+	func rotateDirectionFinish() {
+		mapData.endUndoGrouping()
+		directionRotateTagKey = nil
+		directionRotateInitialBearing = nil
+	}
+
+	func isRotateDirectionMode() -> Bool {
+		directionRotateTagKey != nil
+	}
+
 	// MARK: Editing
 
 	func adjust(_ node: OsmNode, byScreenDistance delta: CGPoint) {
@@ -672,9 +720,12 @@ extension EditorMapLayer {
 					actionList += [.STRAIGHTEN, .REVERSE, .DUPLICATE, .CREATE_RELATION]
 				}
 			}
-		} else if selectedNode != nil {
+		} else if let selectedNode = selectedNode {
 			// node
 			actionList += [.DUPLICATE]
+			if selectedNode.technicalDirectionTagKey != nil {
+				actionList.append(.ROTATE)
+			}
 		} else if let selectedRelation = selectedRelation {
 			// relation
 			if selectedRelation.isMultipolygon() {
@@ -744,7 +795,11 @@ extension EditorMapLayer {
 				selectedRelation = newObject.isRelation()
 				owner.placePushpinForSelection(at: nil)
 			case .ROTATE:
-				guard selectedWay != nil || (selectedRelation?.isMultipolygon() ?? false) else {
+				let canRotateGeometry = selectedWay != nil || (selectedRelation?.isMultipolygon() ?? false)
+				let canRotateDirection = selectedWay == nil &&
+					selectedRelation == nil &&
+					selectedNode?.technicalDirectionTagKey != nil
+				guard canRotateGeometry || canRotateDirection else {
 					throw EditError.text(NSLocalizedString("Only ways/multipolygons can be rotated", comment: ""))
 				}
 				owner.startObjectRotation()

--- a/src/Shared/EditorLayer/EditorMapLayer+Edit.swift
+++ b/src/Shared/EditorLayer/EditorMapLayer+Edit.swift
@@ -460,15 +460,19 @@ extension EditorMapLayer {
 
 	// MARK: Rotate direction tag
 
-	func rotateDirectionBegin() {
+	func prepareDirectionRotation() {
 		guard let node = selectedNode,
 		      let tagKey = node.technicalDirectionTagKey,
 		      let bearing = node.direction?.location
 		else { return }
-		mapData.beginUndoGrouping()
-		dragState.didMove = false
 		directionRotateTagKey = tagKey
 		directionRotateInitialBearing = bearing
+	}
+
+	func rotateDirectionBegin() {
+		mapData.beginUndoGrouping()
+		dragState.didMove = false
+		directionRotateUndoOpen = true
 	}
 
 	func rotateDirectionContinue(delta: CGFloat) {
@@ -493,17 +497,18 @@ extension EditorMapLayer {
 		tags[tagKey] = value
 		mapData.setTags(tags, for: node)
 		setNeedsLayout()
-		owner.didUpdateObject()
 	}
 
 	func rotateDirectionFinish() {
-		mapData.endUndoGrouping()
+		if directionRotateUndoOpen {
+			mapData.endUndoGrouping()
+			directionRotateUndoOpen = false
+		}
+		if dragState.didMove {
+			owner.didUpdateObject()
+		}
 		directionRotateTagKey = nil
 		directionRotateInitialBearing = nil
-	}
-
-	func isRotateDirectionMode() -> Bool {
-		directionRotateTagKey != nil
 	}
 
 	// MARK: Editing
@@ -723,7 +728,7 @@ extension EditorMapLayer {
 		} else if let selectedNode = selectedNode {
 			// node
 			actionList += [.DUPLICATE]
-			if selectedNode.technicalDirectionTagKey != nil {
+			if canRotateSelectedNodeDirection() {
 				actionList.append(.ROTATE)
 			}
 		} else if let selectedRelation = selectedRelation {
@@ -796,10 +801,7 @@ extension EditorMapLayer {
 				owner.placePushpinForSelection(at: nil)
 			case .ROTATE:
 				let canRotateGeometry = selectedWay != nil || (selectedRelation?.isMultipolygon() ?? false)
-				let canRotateDirection = selectedWay == nil &&
-					selectedRelation == nil &&
-					selectedNode?.technicalDirectionTagKey != nil
-				guard canRotateGeometry || canRotateDirection else {
+				guard canRotateGeometry || canRotateSelectedNodeDirection() else {
 					throw EditError.text(NSLocalizedString("Only ways/multipolygons can be rotated", comment: ""))
 				}
 				owner.startObjectRotation()

--- a/src/Shared/EditorLayer/EditorMapLayer.swift
+++ b/src/Shared/EditorLayer/EditorMapLayer.swift
@@ -181,6 +181,15 @@ final class EditorMapLayer: CALayer {
 	/// Active while rotating a node's `direction` / `camera:direction` tag (not geometry).
 	var directionRotateTagKey: String?
 	var directionRotateInitialBearing: Int?
+	var directionRotateUndoOpen = false
+
+	var isRotateDirectionMode: Bool { directionRotateTagKey != nil }
+
+	func canRotateSelectedNodeDirection() -> Bool {
+		selectedWay == nil &&
+			selectedRelation == nil &&
+			selectedNode?.technicalDirectionTagKey != nil
+	}
 
 	let objectFilters = EditorFilters()
 

--- a/src/Shared/EditorLayer/EditorMapLayer.swift
+++ b/src/Shared/EditorLayer/EditorMapLayer.swift
@@ -178,6 +178,10 @@ final class EditorMapLayer: CALayer {
 
 	var dragState = DragState(startPoint: .zero, didMove: false, confirmDrag: false)
 
+	/// Active while rotating a node's `direction` / `camera:direction` tag (not geometry).
+	var directionRotateTagKey: String?
+	var directionRotateInitialBearing: Int?
+
 	let objectFilters = EditorFilters()
 
 	var whiteText = false {

--- a/src/Shared/MapView.swift
+++ b/src/Shared/MapView.swift
@@ -269,11 +269,19 @@ final class MapView: UIView, UIGestureRecognizerDelegate, UIContextMenuInteracti
 		// remove previous rotation in case user pressed Rotate button twice
 		endObjectRotation()
 
+		let isDirectionRotate = editorLayer.selectedWay == nil &&
+			editorLayer.selectedRelation == nil &&
+			editorLayer.selectedNode?.technicalDirectionTagKey != nil
+
 		guard let rotateObjectCenter = editorLayer.selectedNode?.latLon
 			?? editorLayer.selectedWay?.centerPoint()
 			?? editorLayer.selectedRelation?.centerPoint()
 		else {
 			return
+		}
+
+		if isDirectionRotate {
+			editorLayer.rotateDirectionBegin()
 		}
 		removePin()
 		let rotateObjectOverlay = CAShapeLayer()
@@ -303,6 +311,9 @@ final class MapView: UIView, UIGestureRecognizerDelegate, UIContextMenuInteracti
 
 	func endObjectRotation() {
 		isRotateObjectMode?.rotateObjectOverlay.removeFromSuperlayer()
+		if editorLayer.isRotateDirectionMode() {
+			editorLayer.rotateDirectionFinish()
+		}
 		placePushpinForSelection()
 		editorLayer.dragState.confirmDrag = false
 		isRotateObjectMode = nil
@@ -1048,13 +1059,21 @@ final class MapView: UIView, UIGestureRecognizerDelegate, UIContextMenuInteracti
 		}
 		// Rotate object on screen
 		if rotationGesture.state == .began {
-			editorLayer.rotateBegin()
+			if !editorLayer.isRotateDirectionMode() {
+				editorLayer.rotateBegin()
+			}
 		} else if rotationGesture.state == .changed {
-			editorLayer.rotateContinue(delta: rotationGesture.rotation, rotate: rotate)
+			if editorLayer.isRotateDirectionMode() {
+				editorLayer.rotateDirectionContinue(delta: rotationGesture.rotation)
+			} else {
+				editorLayer.rotateContinue(delta: rotationGesture.rotation, rotate: rotate)
+			}
 		} else {
 			// ended
+			if !editorLayer.isRotateDirectionMode() {
+				editorLayer.rotateFinish()
+			}
 			endObjectRotation()
-			editorLayer.rotateFinish()
 		}
 	}
 

--- a/src/Shared/MapView.swift
+++ b/src/Shared/MapView.swift
@@ -269,10 +269,6 @@ final class MapView: UIView, UIGestureRecognizerDelegate, UIContextMenuInteracti
 		// remove previous rotation in case user pressed Rotate button twice
 		endObjectRotation()
 
-		let isDirectionRotate = editorLayer.selectedWay == nil &&
-			editorLayer.selectedRelation == nil &&
-			editorLayer.selectedNode?.technicalDirectionTagKey != nil
-
 		guard let rotateObjectCenter = editorLayer.selectedNode?.latLon
 			?? editorLayer.selectedWay?.centerPoint()
 			?? editorLayer.selectedRelation?.centerPoint()
@@ -280,8 +276,8 @@ final class MapView: UIView, UIGestureRecognizerDelegate, UIContextMenuInteracti
 			return
 		}
 
-		if isDirectionRotate {
-			editorLayer.rotateDirectionBegin()
+		if editorLayer.canRotateSelectedNodeDirection() {
+			editorLayer.prepareDirectionRotation()
 		}
 		removePin()
 		let rotateObjectOverlay = CAShapeLayer()
@@ -311,7 +307,7 @@ final class MapView: UIView, UIGestureRecognizerDelegate, UIContextMenuInteracti
 
 	func endObjectRotation() {
 		isRotateObjectMode?.rotateObjectOverlay.removeFromSuperlayer()
-		if editorLayer.isRotateDirectionMode() {
+		if editorLayer.isRotateDirectionMode {
 			editorLayer.rotateDirectionFinish()
 		}
 		placePushpinForSelection()
@@ -1059,18 +1055,20 @@ final class MapView: UIView, UIGestureRecognizerDelegate, UIContextMenuInteracti
 		}
 		// Rotate object on screen
 		if rotationGesture.state == .began {
-			if !editorLayer.isRotateDirectionMode() {
+			if editorLayer.isRotateDirectionMode {
+				editorLayer.rotateDirectionBegin()
+			} else {
 				editorLayer.rotateBegin()
 			}
 		} else if rotationGesture.state == .changed {
-			if editorLayer.isRotateDirectionMode() {
+			if editorLayer.isRotateDirectionMode {
 				editorLayer.rotateDirectionContinue(delta: rotationGesture.rotation)
 			} else {
 				editorLayer.rotateContinue(delta: rotationGesture.rotation, rotate: rotate)
 			}
 		} else {
 			// ended
-			if !editorLayer.isRotateDirectionMode() {
+			if !editorLayer.isRotateDirectionMode {
 				editorLayer.rotateFinish()
 			}
 			endObjectRotation()

--- a/src/iOS/Direction/OsmNode+Direction.swift
+++ b/src/iOS/Direction/OsmNode+Direction.swift
@@ -58,12 +58,6 @@ extension OsmNode {
 		return nil
 	}
 
-	/// Bearing in degrees clockwise from north for a point direction (`direction` length 0).
-	var directionPointBearing: Int? {
-		guard let range = direction, range.length == 0 else { return nil }
-		return range.location
-	}
-
 	/// OSM tag value for a bearing, preserving arc span when the current direction is a range.
 	func directionTagValue(forBearingDegrees bearing: Int) -> String? {
 		guard let range = direction else { return nil }

--- a/src/iOS/Direction/OsmNode+Direction.swift
+++ b/src/iOS/Direction/OsmNode+Direction.swift
@@ -46,6 +46,35 @@ extension OsmNode {
 		return nil
 	}
 
+	/// Tag key (`direction` or `camera:direction`) whose value parses as a technical bearing, if any.
+	var technicalDirectionTagKey: String? {
+		for key in ["direction", "camera:direction"] {
+			if let value = tags[key],
+			   OsmNode.directionFromString(value) != nil
+			{
+				return key
+			}
+		}
+		return nil
+	}
+
+	/// Bearing in degrees clockwise from north for a point direction (`direction` length 0).
+	var directionPointBearing: Int? {
+		guard let range = direction, range.length == 0 else { return nil }
+		return range.location
+	}
+
+	/// OSM tag value for a bearing, preserving arc span when the current direction is a range.
+	func directionTagValue(forBearingDegrees bearing: Int) -> String? {
+		guard let range = direction else { return nil }
+		let normalized = ((bearing % 360) + 360) % 360
+		if range.length == 0 {
+			return "\(normalized)"
+		}
+		let end = (normalized + range.length) % 360
+		return "\(normalized)-\(end)"
+	}
+
 	private static func directionFromString(_ string: String) -> NSRange? {
 		if let direction = Float(string) ?? cardinalDictionary[string] {
 			return NSMakeRange(Int(direction), 0)

--- a/src/iOS/GoMapTests/OsmNode_DirectionTestCase.swift
+++ b/src/iOS/GoMapTests/OsmNode_DirectionTestCase.swift
@@ -36,6 +36,44 @@ class OsmNode_DirectionTestCase: XCTestCase {
 		XCTAssertEqual(node.direction?.lowerBound, direction)
 	}
 
+	func testTechnicalDirectionTagKeyPrefersDirectionOverCameraDirection() {
+		let node = OsmNode(asUserCreated: "")
+		node.constructTag("direction", value: "90")
+		node.constructTag("camera:direction", value: "180")
+
+		XCTAssertEqual(node.technicalDirectionTagKey, "direction")
+	}
+
+	func testTechnicalDirectionTagKeyUsesCameraDirectionWhenDirectionAbsent() {
+		let node = OsmNode(asUserCreated: "")
+		node.constructTag("camera:direction", value: "45")
+
+		XCTAssertEqual(node.technicalDirectionTagKey, "camera:direction")
+	}
+
+	func testTechnicalDirectionTagKeyIsNilForHighwayForwardBackward() {
+		let node = OsmNode(asUserCreated: "")
+		node.constructTag("highway", value: "stop")
+		node.constructTag("direction", value: "forward")
+
+		XCTAssertNil(node.technicalDirectionTagKey)
+		XCTAssertNil(node.direction)
+	}
+
+	func testDirectionTagValueFormatsPointBearing() {
+		let node = OsmNode(asUserCreated: "")
+		node.constructTag("direction", value: "10")
+
+		XCTAssertEqual(node.directionTagValue(forBearingDegrees: 95), "95")
+	}
+
+	func testDirectionTagValuePreservesRangeSpan() {
+		let node = OsmNode(asUserCreated: "")
+		node.constructTag("direction", value: "90-120")
+
+		XCTAssertEqual(node.directionTagValue(forBearingDegrees: 0), "0-30")
+	}
+
 	func testDirectionShouldParseCardinalDirectionToLowerBound() {
 		let key = "camera:direction"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Mappers who tag standalone POIs with a **technical bearing** (`direction=*` or `camera:direction=*` in degrees, cardinals, or ranges—see `OsmNode+Direction.swift`) can preview the aim on the map as a direction wedge, but adjusting it today means opening the POI editor and using the compass flow (`DirectionViewController` via `PresetValueTextField`).

**Area rotation** is already map-native: choose **Rotate**, use the cyan arc overlay and rotation gesture, and geometry updates in place. **Nodes** without a selected parent way only get **Duplicate**; **Rotate** on a node inside a way still rotates the whole way. Standalone nodes with a direction tag had no equivalent “aim on the map” workflow.

**Goal:** For a **standalone selected node** whose `direction` or `camera:direction` value `OsmNode.direction` can parse, show **Rotate** in the edit menu and enter the same rotation overlay/gesture as areas—but **write the tag** (bearing in degrees, same convention as compass capture and the map wedge) instead of moving the node. Complements `DirectionViewController`; does not replace it.

**Out of scope (this PR):** Nodes that only infer direction from highway `forward`/`backward` on a way; nodes that are members of a way (way rotation unchanged).

---

## Implementation notes (by Cursor)

### When Rotate appears
- In `EditorMapLayer.editActionsAvailable()`, standalone nodes (`selectedNode` only) append `.ROTATE` when `technicalDirectionTagKey != nil`.
- `technicalDirectionTagKey` is added on `OsmNode` and only matches `direction` / `camera:direction` values that `directionFromString` can parse (so `direction=forward` on a `highway=stop` node does **not** qualify).

### Direction-edit rotate mode
- `MapView.startObjectRotation()` detects standalone + technical direction and calls `EditorMapLayer.rotateDirectionBegin()` (undo grouping + stored initial bearing/tag key).
- Same cyan rotation overlay and `UIRotationGestureRecognizer` as geometry rotation.
- `rotateDirectionContinue(delta:)` applies total gesture rotation to the **initial** bearing, writes degrees via `mapData.setTags`, calls `setNeedsLayout()` and `didUpdateObject()` for live wedge preview.
- Tag key preserved: existing `direction` vs `camera:direction`; numeric output like compass UI (`MeasureDirectionViewModel`). Arc spans (`90-120`) keep their width when rotated.
- `endObjectRotation()` finishes direction undo via `rotateDirectionFinish()`.
- Direction-rotate session state (`directionRotateTagKey`, `directionRotateInitialBearing`) lives on the main `EditorMapLayer` class—not in the `+Edit` extension (Swift disallows stored properties in extensions).

### Fallback behavior
- **No parsable direction tag:** Rotate is **not** listed for standalone nodes (same as today). Choosing Rotate on an in-way node without a standalone direction context still requires a way/multipolygon (unchanged error path).

---

## Testing notes (@tordans)

1. **Build** `Go Map!!` scheme on device or simulator (Linux CI cannot run Xcode here).
2. **Unit tests:** Run `GoMapTests` → `OsmNode_DirectionTestCase` (new cases for `technicalDirectionTagKey`, range formatting, highway `forward` exclusion).
3. **Happy path**
   - Select a standalone node with `direction=90` ~~or `camera:direction=180`~~ (e.g. bench, surveillance, viewpoint). – Only tested `direction`, `camera:direction` assumed to also work
   - Confirm **Rotate** appears in the edit toolbar / More sheet.
   - Tap **Rotate** → cyan arc overlay at node; **two-finger rotate** → wedge and tag value update live; release → undo group; tag is integer degrees.
4. **Tag key**
   - Node with only `camera:direction` → rotation updates that key, not `direction`.
5. **Range** (optional): `direction=90-120` → after rotate, still a range with same angular width.
6. **Regression**
   - Closed way / multipolygon: Rotate still moves geometry.
   - Node in way (no standalone selection): Rotate still rotates way, not tag-only.
   - Standalone node **without** direction tag: no Rotate.
   - ~~`highway=stop` + `direction=forward`: no Rotate on standalone (no technical direction).~~ – Not tested (yet)
7. **Sign / feel:** Verify wedge rotation direction matches finger rotation; report if inverted (implementation uses negated gesture delta to align with geometry rotate).


<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>




https://github.com/user-attachments/assets/75c91a0b-672b-43c8-bf45-55f50512980b






</td><td>




https://github.com/user-attachments/assets/1d462cec-ee6b-487f-b8d9-29626be79b4b





</td></tr>
</table>

Ping https://github.com/openstreetmap/iD/pull/12104 and especially https://github.com/openstreetmap/iD/issues/12341 where this idea comes from.