### PR TITLE
POI: hide Attributes for local geometry; All Tags header tap targets

### DIFF
--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 		64348CFE225E867800ADE7FB /* MeasureDirectionViewModelTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64348CFA225E867800ADE7FB /* MeasureDirectionViewModelTestCase.swift */; };
 		64348D01225E8D3F00ADE7FB /* OsmNode+Direction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64348D00225E8D3F00ADE7FB /* OsmNode+Direction.swift */; };
 		64348D03225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64348D02225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift */; };
+		A5E8F2022601CEC900EC0A60 /* POITabBarControllerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E8F2012601CEC900EC0A60 /* POITabBarControllerTestCase.swift */; };
 		64348D13225EAA5D00ADE7FB /* MapViewUITestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64348D12225EAA5D00ADE7FB /* MapViewUITestCase.swift */; };
 		6442666722540EDF00C0D545 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6442666422540EDF00C0D545 /* Lock.swift */; };
 		6442666822540EDF00C0D545 /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6442666522540EDF00C0D545 /* Disposable.swift */; };
@@ -591,6 +592,7 @@
 		64348CFA225E867800ADE7FB /* MeasureDirectionViewModelTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeasureDirectionViewModelTestCase.swift; sourceTree = "<group>"; };
 		64348D00225E8D3F00ADE7FB /* OsmNode+Direction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OsmNode+Direction.swift"; sourceTree = "<group>"; };
 		64348D02225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OsmNode_DirectionTestCase.swift; sourceTree = "<group>"; };
+		A5E8F2012601CEC900EC0A60 /* POITabBarControllerTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POITabBarControllerTestCase.swift; sourceTree = "<group>"; };
 		64348D08225EA24E00ADE7FB /* GoMapUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GoMapUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		64348D0C225EA24E00ADE7FB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		64348D12225EAA5D00ADE7FB /* MapViewUITestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewUITestCase.swift; sourceTree = "<group>"; };
@@ -1188,6 +1190,7 @@
 				64348CFA225E867800ADE7FB /* MeasureDirectionViewModelTestCase.swift */,
 				64348CF6225E867800ADE7FB /* Mocks */,
 				64348D02225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift */,
+				A5E8F2012601CEC900EC0A60 /* POITabBarControllerTestCase.swift */,
 				64348CEC225E7CD900ADE7FB /* GoMapTests.swift */,
 				64C072FC22622B9C00598078 /* Vendor */,
 				64348CEE225E7CD900ADE7FB /* Info.plist */,
@@ -1815,6 +1818,7 @@
 				64E21EB822651F2D004605D7 /* XCTestCase+UserDefaults.swift in Sources */,
 				64348CFD225E867800ADE7FB /* CLHeadingMock.swift in Sources */,
 				64348D03225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift in Sources */,
+				A5E8F2022601CEC900EC0A60 /* POITabBarControllerTestCase.swift in Sources */,
 				64E21EB522651C06004605D7 /* OSMMapDataTestCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/iOS/GoMapTests/POITabBarControllerTestCase.swift
+++ b/src/iOS/GoMapTests/POITabBarControllerTestCase.swift
@@ -1,0 +1,91 @@
+//
+//  POITabBarControllerTestCase.swift
+//  GoMapTests
+//
+
+@testable import Go_Map__
+import XCTest
+
+class POITabBarControllerTestCase: XCTestCase {
+	// MARK: shouldHideAttributesTab
+
+	func testShouldHideAttributesTabIsTrueForNilSelection() {
+		XCTAssertTrue(POITabBarController.shouldHideAttributesTab(for: nil))
+	}
+
+	func testShouldHideAttributesTabIsTrueForPendingNode() {
+		let node = OsmNode(asUserCreated: "")
+		XCTAssertLessThan(node.ident, 0)
+		XCTAssertTrue(POITabBarController.shouldHideAttributesTab(for: node))
+	}
+
+	func testShouldHideAttributesTabIsFalseForUploadedNode() {
+		let node = OsmNode(
+			withVersion: 1,
+			changeset: 0,
+			user: "",
+			uid: 0,
+			ident: 1,
+			timestamp: "",
+			tags: [:])
+		XCTAssertGreaterThan(node.ident, 0)
+		XCTAssertFalse(POITabBarController.shouldHideAttributesTab(for: node))
+	}
+
+	func testShouldHideAttributesTabIsTrueForPendingWay() {
+		let way = OsmWay(asUserCreated: "")
+		XCTAssertLessThan(way.ident, 0)
+		XCTAssertTrue(POITabBarController.shouldHideAttributesTab(for: way))
+	}
+
+	// MARK: resolvedTabBar
+
+	func testResolvedTabBarNilSelection() {
+		assertResolvedTabBar(savedIndex: 0, selection: nil, expectedTabCount: 2, expectedSelectedIndex: 0)
+		assertResolvedTabBar(savedIndex: 1, selection: nil, expectedTabCount: 2, expectedSelectedIndex: 1)
+		assertResolvedTabBar(savedIndex: 2, selection: nil, expectedTabCount: 2, expectedSelectedIndex: 0)
+	}
+
+	func testResolvedTabBarPendingNode() {
+		let node = OsmNode(asUserCreated: "")
+		assertResolvedTabBar(savedIndex: 0, selection: node, expectedTabCount: 2, expectedSelectedIndex: 0)
+		assertResolvedTabBar(savedIndex: 1, selection: node, expectedTabCount: 2, expectedSelectedIndex: 1)
+		assertResolvedTabBar(savedIndex: 2, selection: node, expectedTabCount: 2, expectedSelectedIndex: 0)
+	}
+
+	func testResolvedTabBarUploadedNode() {
+		let node = OsmNode(
+			withVersion: 1,
+			changeset: 0,
+			user: "",
+			uid: 0,
+			ident: 42,
+			timestamp: "",
+			tags: [:])
+		assertResolvedTabBar(savedIndex: 0, selection: node, expectedTabCount: 3, expectedSelectedIndex: 0)
+		assertResolvedTabBar(savedIndex: 1, selection: node, expectedTabCount: 3, expectedSelectedIndex: 1)
+		assertResolvedTabBar(savedIndex: 2, selection: node, expectedTabCount: 3, expectedSelectedIndex: 2)
+	}
+
+	func testResolvedTabBarPendingWay() {
+		let way = OsmWay(asUserCreated: "")
+		assertResolvedTabBar(savedIndex: 0, selection: way, expectedTabCount: 2, expectedSelectedIndex: 0)
+		assertResolvedTabBar(savedIndex: 1, selection: way, expectedTabCount: 2, expectedSelectedIndex: 1)
+		assertResolvedTabBar(savedIndex: 2, selection: way, expectedTabCount: 2, expectedSelectedIndex: 0)
+	}
+
+	// MARK: Helpers
+
+	private func assertResolvedTabBar(
+		savedIndex: Int,
+		selection: OsmBaseObject?,
+		expectedTabCount: Int,
+		expectedSelectedIndex: Int,
+		file: StaticString = #file,
+		line: UInt = #line
+	) {
+		let result = POITabBarController.resolvedTabBar(savedIndex: savedIndex, selection: selection)
+		XCTAssertEqual(result.tabCount, expectedTabCount, file: file, line: line)
+		XCTAssertEqual(result.selectedIndex, expectedSelectedIndex, file: file, line: line)
+	}
+}

--- a/src/iOS/Localizable.xcstrings
+++ b/src/iOS/Localizable.xcstrings
@@ -25453,6 +25453,9 @@
         }
       }
     },
+    "Change preset" : {
+
+    },
     "Changeset" : {
       "comment" : "OSM changeset identifier",
       "localizations" : {
@@ -46841,6 +46844,9 @@
         }
       }
     },
+    "Opens the preset picker" : {
+
+    },
     "OSM Data" : {
       "comment" : "Delete cached data",
       "localizations" : {
@@ -54467,6 +54473,9 @@
           }
         }
       }
+    },
+    "Shows Common Tags" : {
+
     },
     "Something went wrong while attempting to restore your data. Any pending changes have been lost. Sorry." : {
       "localizations" : {

--- a/src/iOS/POI/POIAllTagsViewController.swift
+++ b/src/iOS/POI/POIAllTagsViewController.swift
@@ -13,8 +13,8 @@ private let EDIT_RELATIONS = false
 private class SectionHeaderCell: UITableViewHeaderFooterView {
 	static let reuseIdentifier = "SectionHeaderCell"
 
-	let label = UILabel()
-	let button = UIButton()
+	let titleButton = UIButton(type: .system)
+	let changeFeatureButton = UIButton(type: .system)
 
 	override init(reuseIdentifier: String?) {
 		super.init(reuseIdentifier: reuseIdentifier)
@@ -27,30 +27,73 @@ private class SectionHeaderCell: UITableViewHeaderFooterView {
 	}
 
 	func configureContents() {
-		label.translatesAutoresizingMaskIntoConstraints = false
-		button.translatesAutoresizingMaskIntoConstraints = false
+		titleButton.translatesAutoresizingMaskIntoConstraints = false
+		changeFeatureButton.translatesAutoresizingMaskIntoConstraints = false
 
-		if #available(iOS 13.0, *) {
-			label.textColor = UIColor.secondaryLabel
+		titleButton.contentHorizontalAlignment = .leading
+		titleButton.addTarget(self, action: #selector(showCommonTagsTab(_:)), for: .touchUpInside)
+		titleButton.accessibilityHint = NSLocalizedString("Shows Common Tags", comment: "")
+
+		changeFeatureButton.accessibilityLabel = NSLocalizedString("Change preset", comment: "")
+		changeFeatureButton.accessibilityHint = NSLocalizedString("Opens the preset picker", comment: "")
+		changeFeatureButton.addTarget(self, action: #selector(pickFeature(_:)), for: .touchUpInside)
+
+		if #available(iOS 15.0, *) {
+			var titleConfig = UIButton.Configuration.plain()
+			if #available(iOS 13.0, *) {
+				titleConfig.baseForegroundColor = UIColor.secondaryLabel
+			} else {
+				titleConfig.baseForegroundColor = UIColor.darkGray
+			}
+			titleConfig.contentInsets = .zero
+			titleButton.configuration = titleConfig
+
+			var featureConfig = UIButton.Configuration.plain()
+			featureConfig.image = UIImage(systemName: "chevron.right")
+			featureConfig.baseForegroundColor = UIColor.systemBlue
+			changeFeatureButton.configuration = featureConfig
 		} else {
-			label.textColor = UIColor.darkGray
+			if #available(iOS 13.0, *) {
+				titleButton.setTitleColor(UIColor.secondaryLabel, for: .normal)
+				changeFeatureButton.setImage(UIImage(systemName: "chevron.right"), for: .normal)
+			} else {
+				titleButton.setTitleColor(UIColor.darkGray, for: .normal)
+				changeFeatureButton.setTitle(">", for: .normal)
+			}
+			changeFeatureButton.tintColor = UIColor.systemBlue
 		}
-		button.setTitle(">", for: .normal)
-		button.setTitleColor(UIColor.systemBlue, for: .normal)
-		button.addTarget(self, action: #selector(pickFeature(_:)), for: .touchUpInside)
 
-		contentView.addSubview(label)
-		contentView.addSubview(button)
+		contentView.addSubview(titleButton)
+		contentView.addSubview(changeFeatureButton)
 
 		NSLayoutConstraint.activate([
-			label.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-			label.leadingAnchor.constraint(equalToSystemSpacingAfter: contentView.leadingAnchor, multiplier: 1.0),
-			label.trailingAnchor.constraint(greaterThanOrEqualTo: button.leadingAnchor, constant: 10.0),
+			titleButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+			titleButton.leadingAnchor.constraint(equalToSystemSpacingAfter: contentView.leadingAnchor, multiplier: 1.0),
+			titleButton.trailingAnchor.constraint(greaterThanOrEqualTo: changeFeatureButton.leadingAnchor, constant: 10.0),
 
-			button.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-			button.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor, constant: 10.0),
-			button.widthAnchor.constraint(equalToConstant: 44.0)
+			changeFeatureButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+			changeFeatureButton.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor, constant: 10.0),
+			changeFeatureButton.widthAnchor.constraint(equalToConstant: 44.0),
+			changeFeatureButton.heightAnchor.constraint(equalToConstant: 44.0)
 		])
+	}
+
+	func setPresetTitle(_ text: String) {
+		if #available(iOS 15.0, *) {
+			var config = titleButton.configuration ?? .plain()
+			config.title = text
+			titleButton.configuration = config
+		} else {
+			titleButton.setTitle(text, for: .normal)
+		}
+		titleButton.accessibilityLabel = text
+	}
+
+	@objc func showCommonTagsTab(_ sender: Any?) {
+		guard let tabBar = tabBarController as? POITabBarController else { return }
+		UserPrefs.shared.poiTabIndex.value = 0
+		guard tabBar.selectedIndex != 0 else { return }
+		tabBar.slideTabTo(tabIndex: 0)
 	}
 
 	@objc func pickFeature(_ sender: Any?) {
@@ -467,7 +510,7 @@ class POIAllTagsViewController: UITableViewController, POIFeaturePickerDelegate,
 			let cell: SectionHeaderCell = tableView
 				.dequeueReusableHeaderFooterView(withIdentifier: SectionHeaderCell
 					.reuseIdentifier) as! SectionHeaderCell
-			cell.label.text = currentFeature?.localizedName.uppercased() ?? "TAGS"
+			cell.setPresetTitle(currentFeature?.localizedName.uppercased() ?? "TAGS")
 			return cell
 		} else {
 			return nil

--- a/src/iOS/POI/POIAllTagsViewController.swift
+++ b/src/iOS/POI/POIAllTagsViewController.swift
@@ -90,10 +90,17 @@ private class SectionHeaderCell: UITableViewHeaderFooterView {
 	}
 
 	@objc func showCommonTagsTab(_ sender: Any?) {
-		guard let tabBar = tabBarController as? POITabBarController else { return }
-		UserPrefs.shared.poiTabIndex.value = 0
-		guard tabBar.selectedIndex != 0 else { return }
-		tabBar.slideTabTo(tabIndex: 0)
+		var r: UIResponder = self
+		while true {
+			if let tabBar = r as? POITabBarController {
+				UserPrefs.shared.poiTabIndex.value = 0
+				guard tabBar.selectedIndex != 0 else { return }
+				tabBar.slideTabTo(tabIndex: 0)
+				return
+			}
+			guard let next = r.next else { return }
+			r = next
+		}
 	}
 
 	@objc func pickFeature(_ sender: Any?) {

--- a/src/iOS/POI/POITabBarController.swift
+++ b/src/iOS/POI/POITabBarController.swift
@@ -21,15 +21,12 @@ class POITabBarController: UITabBarController {
 		keyValueDict = selection?.tags ?? [:]
 		relationList = selection?.parentRelations ?? []
 
-		let hideAttributesTab = Self.shouldHideAttributesTab(for: selection)
-		var tabIndex = UserPrefs.shared.poiTabIndex.value ?? 0
-		if hideAttributesTab, tabIndex == 2 {
-			tabIndex = 0
-		}
-		if hideAttributesTab {
+		let savedIndex = UserPrefs.shared.poiTabIndex.value ?? 0
+		let resolved = Self.resolvedTabBar(savedIndex: savedIndex, selection: selection)
+		if resolved.tabCount == 2 {
 			removeAttributesTabFromViewControllers()
 		}
-		selectedIndex = tabIndex
+		selectedIndex = resolved.selectedIndex
 
 		if #available(iOS 17, *) {
 			// On MacCatalyst (and maybe iPad) UITabBar is broken.
@@ -67,9 +64,23 @@ class POITabBarController: UITabBarController {
 	}
 
 	/// Attributes are only useful for objects that exist on the server (positive OSM id).
-	private static func shouldHideAttributesTab(for selection: OsmBaseObject?) -> Bool {
+	static func shouldHideAttributesTab(for selection: OsmBaseObject?) -> Bool {
 		guard let selection else { return true }
 		return selection.ident < 0
+	}
+
+	/// Tab order: 0 Common Tags, 1 All Tags, 2 Attributes.
+	static func resolvedTabBar(
+		savedIndex: Int,
+		selection: OsmBaseObject?
+	) -> (tabCount: Int, selectedIndex: Int) {
+		let hideAttributes = shouldHideAttributesTab(for: selection)
+		let tabCount = hideAttributes ? 2 : 3
+		var selectedIndex = savedIndex
+		if hideAttributes, savedIndex == 2 {
+			selectedIndex = 0
+		}
+		return (tabCount, selectedIndex)
 	}
 
 	private func removeAttributesTabFromViewControllers() {

--- a/src/iOS/POI/POITabBarController.swift
+++ b/src/iOS/POI/POITabBarController.swift
@@ -21,22 +21,15 @@ class POITabBarController: UITabBarController {
 		keyValueDict = selection?.tags ?? [:]
 		relationList = selection?.parentRelations ?? []
 
+		let hideAttributesTab = Self.shouldHideAttributesTab(for: selection)
 		var tabIndex = UserPrefs.shared.poiTabIndex.value ?? 0
-		if tabIndex == 2,
-		   selection == nil
-		{
+		if hideAttributesTab, tabIndex == 2 {
 			tabIndex = 0
 		}
-		if selection == nil {
-			// don't show attributes page
-			var vcList = viewControllers!
-			vcList.removeLast()
-			self.viewControllers = vcList
+		if hideAttributesTab {
+			removeAttributesTabFromViewControllers()
 		}
 		selectedIndex = tabIndex
-
-		// hide attributes tab on new objects
-		updatePOIAttributesTabBarItemVisibility(withSelectedObject: selection)
 
 		if #available(iOS 17, *) {
 			// On MacCatalyst (and maybe iPad) UITabBar is broken.
@@ -73,27 +66,17 @@ class POITabBarController: UITabBarController {
 		selectedViewController?.dismiss(animated: true)
 	}
 
-	/// Hides the POI attributes tab bar item when the user is adding a new item, since it doesn't have any attributes yet.
-	/// - Parameter selectedObject: The object that the user selected on the map.
-	func updatePOIAttributesTabBarItemVisibility(withSelectedObject selectedObject: OsmBaseObject?) {
-		let isAddingNewItem = selectedObject == nil
-		if isAddingNewItem {
-			// Remove the `POIAttributesViewController`.
-			var viewControllersToKeep: [UIViewController] = []
-			for controller in viewControllers ?? [] {
-				if controller is UINavigationController,
-				   (controller as? UINavigationController)?.viewControllers.first is POIAttributesViewController
-				{
-					// For new objects, the navigation controller that contains the view controller
-					// for POI attributes is not needed; ignore it.
-					return
-				} else {
-					viewControllersToKeep.append(controller)
-				}
-			}
+	/// Attributes are only useful for objects that exist on the server (positive OSM id).
+	private static func shouldHideAttributesTab(for selection: OsmBaseObject?) -> Bool {
+		guard let selection else { return true }
+		return selection.ident < 0
+	}
 
-			setViewControllers(viewControllersToKeep, animated: false)
-		}
+	private func removeAttributesTabFromViewControllers() {
+		var vcList = viewControllers ?? []
+		guard vcList.count > 2 else { return }
+		vcList.removeLast()
+		viewControllers = vcList
 	}
 
 	func setFeatureKey(_ key: String, value: String?) {


### PR DESCRIPTION

## Problem

This changes two things at once because I mixed up my instructions. But they are related, so maybe they can stay in one PR.

### Hide Attributes for local / new geometry

**Issue 1: The 3rd tab "Attributes" was hidden for new nodes but not for new ways/areas**

`POITabBarController` restores `UserPrefs.poiTabIndex` when the POI editor opens (0 = Common Tags, 1 = All Tags, 2 = Attributes).

For a **new standalone node** (`selectedPrimary == nil`), the Attributes tab is already removed and a saved index of **2** is clamped to **0**.

For a **new way / area / relation** in memory (`ident < 0` until upload), `selectedPrimary` is non-nil, so Attributes used to stay visible and index **2** could still be restored—inconsistent with the new-node experience.

**User story:** After editing an uploaded object on Attributes, opening the editor for **any** not-yet-uploaded geometry (nil selection or local negative id) should match a new node: only Common Tags and All Tags; Attributes returns after the object has a positive server id.

> **Consolidation:** [PR #6](https://github.com/tordans/GoMap/pull/6) addressed the same Attributes-tab bug. This PR keeps that fix plus the All Tags header work below. PR #6 is closed as superseded; unit tests from #6 are included here (`POITabBarControllerTestCase`).

### All Tags preset header

**Issue 2a: The "change/choose preset" arrow on the "All Tags" did not look that great**
**Issue 2b: When the keyboard was up (which happens automatically in some flows), there is no direct way to change from "All Tags" to "Common Tags" => This is now solved by making the Preset label clickable**

On **All Tags**, the section header shows the matched preset name and a control to open the feature picker. When the keyboard hides the tab bar, users could not easily return to **Common Tags** preset fields. The trailing control was plain `">"` text.

**User story:** Tap the preset **title** → Common Tags; tap the chevron → change preset (unchanged behavior).

---

## Implementation notes (Cursor)

### `POITabBarController.swift`

- `shouldHideAttributesTab(for:)` — `true` when `selection == nil` or `ident < 0`.
- `resolvedTabBar(savedIndex:selection:)` — tab count 2 vs 3; clamps saved index **2 → 0** when Attributes hidden.
- `viewDidLoad` uses `resolvedTabBar`; `removeAttributesTabFromViewControllers()` strips the Attributes nav stack.

### `POIAllTagsViewController.swift` (`SectionHeaderCell`)

- **Title**: `slideTabTo(tabIndex: 0)` + updates `poiTabIndex`; does not open feature picker.
- **Trailing**: `chevron.right`, accessibility “Change preset”; pushes `POIFeaturePickerViewController`.
- `UIButton.Configuration` on iOS 15+; fallback on older OS.

### Tests (from PR #6)

- `POITabBarControllerTestCase` — matrix for `savedIndex` ∈ {0,1,2} × {nil, pending node, uploaded node, pending way}.

**Out of scope:** Refreshing tabs if selection goes pending → uploaded while POI stays open.

---

## Testing notes (@tordans)

### POI tab / Attributes visibility

1. **Uploaded node** → Attributes → then **new node** (pushpin) → two tabs only; if last index was 2, land on **Common Tags**.
2. Same with last session on **Attributes** (index 2) before new node → **Common Tags**, no Attributes.
3. **New way/area** (`ident < 0`) → POI → Attributes hidden; index 2 does not select a missing third tab.
4. After **upload** or **existing** object (`ident > 0`) → three tabs; index 2 restores normally.

### All Tags header

1. Tags present → **All Tags** → keyboard up → tap **header title** → **Common Tags**.
2. Tap **chevron** → feature picker; title must not open picker.
3. **VoiceOver:** two elements; “Change preset” on chevron.
4. **iPad / Mac Catalyst:** trailing control ≥ 44pt.



<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>



https://github.com/user-attachments/assets/7b6e3d62-1fe5-42e2-a519-e84207fa2757





</td><td>



https://github.com/user-attachments/assets/021d4f92-527a-41e1-a2a3-ea222c066555




</td></tr>
</table>


**Automated:** Run `GoMapTests` — `POITabBarControllerTestCase`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63c9d281-b7bd-4148-a4ad-d9cf82e8a5db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63c9d281-b7bd-4148-a4ad-d9cf82e8a5db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

