### PR TITLE
Map fixme markers: light blue when object is a relation member

### DIFF
--- a/src/Shared/MapMarkers/FixmeMarker.swift
+++ b/src/Shared/MapMarkers/FixmeMarker.swift
@@ -7,9 +7,15 @@
 //
 
 import Foundation
+import UIKit
 
 // An OSM object containing a fixme= tag
 final class FixmeMarker: MapMarker {
+	/// Same light blue as relation member highlighting in EditorMapLayer.
+	private static let relationMemberColor = UIColor(red: 66 / 255.0,
+	                                                 green: 188 / 255.0,
+	                                                 blue: 244 / 255.0,
+	                                                 alpha: 1.0)
 	let fixmeID: OsmExtendedIdentifier
 
 	override var markerIdentifier: String {
@@ -38,6 +44,28 @@ final class FixmeMarker: MapMarker {
 	}
 
 	override var buttonLabel: String { "F" }
+
+	private var isRelationMember: Bool {
+		guard let object = object else { return false }
+		return !object.parentRelations.isEmpty
+	}
+
+	override func makeButton() -> UIButton {
+		let button = super.makeButton()
+		applyButtonStyle()
+		return button
+	}
+
+	override func reuseButtonFrom(_ other: MapMarker) {
+		super.reuseButtonFrom(other)
+		applyButtonStyle()
+	}
+
+	private func applyButtonStyle() {
+		guard let button = button else { return }
+		let color = isRelationMember ? Self.relationMemberColor : .blue
+		button.layer.backgroundColor = color.cgColor
+	}
 
 	override func handleButtonPress(in mainView: MainViewController, markerView: MapMarkersView) {
 		if mainView.mapView.isHidden {


### PR DESCRIPTION
## Problem

Selecting a **relation** on the map highlights its member ways (and other members) in a distinctive **light blue** (`EditorMapLayer` uses `relationColor`, RGB 66/188/244). Separately, objects tagged with **`fixme=*`** get a small **“F”** map marker (`FixmeMarker` via `MapMarkerDatabase`).

Today, relation member highlighting and fixme markers are unrelated visually. Every fixme badge uses the same generic **blue** button styling from `MapMarker.makeButton()`, whether the tagged object stands alone or belongs to one or more **relations**.

**Problem:** Fixmes on **relation members** are often not something mappers can resolve inside Go Map (they may require external tools, relation-level edits, or context the app does not expose). When scanning the map, those markers look the same as fixmes on ordinary nodes and ways, so they add noise without signaling “this is relation-scoped / probably not actionable here.”

**Desired behavior:** When a **`fixme=*`** marker is placed on an object that is a **member of at least one relation**, tint the marker with the **same light blue** as relation member highlighting—not the default fixme blue. Fixmes on non-relation objects keep today’s styling.

**Why:** Gives an at-a-glance visual filter: relation-bound fixmes read as a distinct category, so mappers can mentally (or eventually via marker filters) de-emphasize them while focusing on fixmes they can actually address in the editor.

---

## Implementation notes (by Cursor)

- **Branch:** `cursor/fixme-relation-member-color-6fc2`
- **File changed:** `src/Shared/MapMarkers/FixmeMarker.swift`
- **Logic:** After creating or reusing a marker button, `FixmeMarker` checks `object.parentRelations.isEmpty`. If the object has at least one parent relation (via `OsmMapData`’s parent-relation cache, same source used elsewhere in the app), the button background uses light blue `UIColor(red: 66/255, green: 188/255, blue: 244/255, alpha: 1)`—matching `relationColor` in `EditorMapLayer`. Otherwise it keeps the default `.blue` from `MapMarker.makeButton()`.
- **Hooks:** Overrides `makeButton()` (first display) and `reuseButtonFrom(_:)` (region refresh / marker refresh) so existing buttons pick up the correct color when relations load or membership changes.
- **Scope:** Visual-only; no changes to fixme discovery, tap behavior, or overlay toggles.

---

## Testing notes (@tordans)

Test Location: https://www.openstreetmap.org/way/1105973680

1. **Standalone fixme** — Node or way with `fixme=*` and **no** parent relations → **F** marker should remain **default blue**.
2. **Relation member fixme** — Way (or node) that is a member of a relation (e.g. multipolygon outer, route relation member) and has `fixme=*` → **F** marker should be **light blue** (same hue as selected-relation member highlighting).
3. **Multiple relations** — Member of more than one relation with `fixme=*` → still light blue.
4. **Pan/zoom refresh** — Pan away and back, or zoom to trigger marker refresh; colors should stay correct after relations are loaded.
5. **Regression** — Tap fixme marker still opens tag editor (map visible) or shows fixme text alert (map hidden); other marker types (notes, quests, KeepRight) unchanged.



<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>



https://github.com/user-attachments/assets/dbaca970-fef1-40fe-a79d-cd050c5d776f






</td><td>




https://github.com/user-attachments/assets/fcbb7290-e803-426c-b7fa-22ddd98cff97




</td></tr>
</table>


