### PR TITLE
Changeset comment field: replace Return with '✔️' on the virtual keyboard

### DIFF
--- a/src/iOS/Upload/UploadViewController.swift
+++ b/src/iOS/Upload/UploadViewController.swift
@@ -61,6 +61,8 @@ class UploadViewController: UIViewController, UITextViewDelegate {
 		xmlTextView.layer.borderWidth = 2.0
 		xmlTextView.layer.cornerRadius = 10.0
 
+		commentTextView.returnKeyType = .done
+
 		// create button for source history
 		sourceHistoryButton = UIButton(type: .custom)
 		sourceHistoryButton.frame = CGRect(x: 0, y: 0, width: 22, height: 22)

--- a/src/iOS/Upload/UploadViewController.swift
+++ b/src/iOS/Upload/UploadViewController.swift
@@ -52,16 +52,17 @@ class UploadViewController: UIViewController, UITextViewDelegate {
 		commentContainerView.layer.borderColor = color.cgColor
 		commentContainerView.layer.borderWidth = 2.0
 		commentContainerView.layer.cornerRadius = 10.0
+		commentTextView.returnKeyType = .done
 
 		sourceTextField.layer.borderColor = color.cgColor
 		sourceTextField.layer.borderWidth = 2.0
 		sourceTextField.layer.cornerRadius = 10.0
+		sourceTextField.returnKeyType = .done
+		sourceTextField.addTarget(self, action: #selector(dismissKeyboard(_:)), for: .editingDidEndOnExit)
 
 		xmlTextView.layer.borderColor = color.cgColor
 		xmlTextView.layer.borderWidth = 2.0
 		xmlTextView.layer.cornerRadius = 10.0
-
-		commentTextView.returnKeyType = .done
 
 		// create button for source history
 		sourceHistoryButton = UIButton(type: .custom)
@@ -124,6 +125,10 @@ class UploadViewController: UIViewController, UITextViewDelegate {
 			return false
 		}
 		return true
+	}
+
+	@objc func dismissKeyboard(_ sender: UITextField) {
+		sender.resignFirstResponder()
 	}
 
 	@IBAction func clearCommentText(_ sender: Any) {


### PR DESCRIPTION
In order to indicate that multiline inputs are not accepted and the keyboard will close upon pressing the Return key.

_I've tested it and it works well._