### PR TITLE
Remove the thin rectangle around the 'Source:' text input field

### DIFF
--- a/src/iOS/Upload/Base.lproj/Changeset.storyboard
+++ b/src/iOS/Upload/Base.lproj/Changeset.storyboard
@@ -69,8 +69,11 @@
                                 <rect key="frame" x="188.5" y="308" width="37" height="37"/>
                                 <color key="color" systemColor="labelColor"/>
                             </activityIndicatorView>
-                            <textField opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="500" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="survey, Bing, etc." textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ps9-Hb-Vow">
+                            <textField opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="500" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="none" placeholder="survey, Bing, etc." textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ps9-Hb-Vow">
                                 <rect key="frame" x="86.5" y="272" width="307.5" height="34"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="35" id="ps9-Hb-Hgt"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>

--- a/src/iOS/Upload/UploadViewController.swift
+++ b/src/iOS/Upload/UploadViewController.swift
@@ -56,6 +56,8 @@ class UploadViewController: UIViewController, UITextViewDelegate {
 		sourceTextField.layer.borderColor = color.cgColor
 		sourceTextField.layer.borderWidth = 2.0
 		sourceTextField.layer.cornerRadius = 10.0
+		sourceTextField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 7.5, height: 0))
+		sourceTextField.leftViewMode = .always
 
 		xmlTextView.layer.borderColor = color.cgColor
 		xmlTextView.layer.borderWidth = 2.0


### PR DESCRIPTION
Before:
<img width="1178" height="519" alt="IMG_9124" src="https://github.com/user-attachments/assets/e102f864-4867-4557-a947-887243aa4091" />

After:
<img width="1178" height="513" alt="IMG_9125" src="https://github.com/user-attachments/assets/a9990c25-ebac-48e7-bd3b-02e1e1a9ae24" />
