### PR TITLE
feat: refresh common tags on value change

### DIFF
--- a/src/iOS/POI/POICommonTagsViewController.swift
+++ b/src/iOS/POI/POICommonTagsViewController.swift
@@ -145,9 +145,45 @@ class POICommonTagsViewController: UITableViewController, UITextFieldDelegate, U
 		if let indexPath = indexPathFor(key: key),
 		   setBothValuesFor(indexPath: indexPath, value: value)
 		{
+			refreshPresetsIfFieldSetChanged()
 			return
 		}
 		updateTagDictLow(withValue: value, forKey: key)
+		refreshPresetsIfFieldSetChanged()
+	}
+
+	private func refreshPresetsIfFieldSetChanged() {
+		guard drillDownGroup == nil,
+		      let tabController = tabBarController as? POITabBarController
+		else { return }
+
+		let currentSignature = allPresets?.allPresetKeys().map { $0.tagKey } ?? []
+		let object = tabController.selection
+		let geometry = object?.geometry() ?? GEOMETRY.POINT
+		// Mirror updatePresets()'s update closure so newly revealed fields whose
+		// value lists come from TagInfo still get their async refresh installed.
+		let newPresets = PresetDisplayForFeature(
+			withFeature: currentFeature,
+			objectTags: tabController.keyValueDict,
+			geometry: geometry,
+			update: { [weak self] in
+				if let self,
+				   !self.isEditing
+				{
+					self.allPresets = PresetDisplayForFeature(
+						withFeature: self.currentFeature,
+						objectTags: tabController.keyValueDict,
+						geometry: geometry,
+						update: nil)
+					self.tableView.reloadData()
+				}
+			})
+		let newSignature = newPresets.allPresetKeys().map { $0.tagKey }
+
+		if currentSignature != newSignature {
+			allPresets = newPresets
+			tableView.reloadData()
+		}
 	}
 
 	func updatePresets() {
@@ -629,9 +665,12 @@ class POICommonTagsViewController: UITableViewController, UITextFieldDelegate, U
 		if editingStyle == .delete {
 			// user swiped to delete a cell
 			if indexPath.section == allPresets?.sectionCount() {
-				// Extra tags section
-				updateTagDict(withValue: "", forKey: extraTags[indexPath.row].k)
+				// Extra tags section. Remove from the row model before updating the
+				// tag dict, because updateTagDict() may rebuild presets/extraTags and
+				// reload the table, which would invalidate this index path.
+				let key = extraTags[indexPath.row].k
 				extraTags.remove(at: indexPath)
+				updateTagDict(withValue: "", forKey: key)
 			} else {
 				// for regular cells just set the value to ""
 				let cell = tableView.cellForRow(at: indexPath)


### PR DESCRIPTION
## Summary

On the Common Tags page, dependent preset fields now appear as soon as the parent value is set, without leaving and re-entering the object. For example, setting `toilets=yes` immediately reveals the "Wheelchair Accessible Toilet" and "Free Menstrual Products Available" fields.

When a value edit changes the keyValueDict, `updateTagDict(withValue:forKey:)` now recomputes the applicable preset field list and reloads the table only when that field set actually changes. Edits that do not gate any additional fields (e.g. a plain Name change) produce no reload.

## Why this matters

Fixes the inconsistency reported in #951, where some dependent fields (`internet_access` revealing fee / network name) refreshed but others (`toilets`) did not until navigating away and back.

The implementation diffs the computed field-key signature before reloading, so the table is rebuilt only when the visible field set genuinely changes. This directly addresses the concern in the issue thread that refreshing the whole field list on every value change "is going to be an unpleasant user experience" - unaffected edits cause no visible reload.

Details:
- The recompute mirrors the existing `updatePresets()` rebuild, including its async TagInfo `update:` closure, so newly revealed fields whose value lists come from TagInfo still get their async refresh installed.
- Drill-down subgroups are guarded out (they display a fixed group and must not be rebuilt).
- The extra-tags swipe-to-delete path removes from the row model before mutating the tag dict, so the new reload cannot invalidate the in-flight index path.

## Testing

- Built for the iOS Simulator with `xcodebuild ... -scheme "Go Map!!" build` (BUILD SUCCEEDED).
- Reviewed the diff against the existing `PresetDisplayForFeature` / `POICommonTagsViewController` patterns. A full interactive simulator run-through is not included here.

Fixes #951
