### PR TITLE
Select a tagged member way before its multipolygon parent (#969)

### DIFF
--- a/src/Shared/EditorLayer/EditorMapLayer+Edit.swift
+++ b/src/Shared/EditorLayer/EditorMapLayer+Edit.swift
@@ -167,24 +167,14 @@ extension EditorMapLayer {
 						// selecting way inside previously selected relation
 						selectedNode = nil
 						selectedWay = hit
-					} else if hit.parentRelations.count > 0 {
-						// select relation the way belongs to
-						var relations = hit.parentRelations.filter { relation in
-							relation.isMultipolygon() || relation.isBoundary() || relation.isWaterway()
-						}
-						if relations.count == 0, !hit.hasInterestingTags() {
-							// if the way doesn't have tags then always promote to containing relation
-							relations = hit.parentRelations
-						}
-						if let relation = relations.first {
-							selectedNode = nil
-							selectedWay = nil
-							selectedRelation = relation
-						} else {
-							selectedNode = nil
-							selectedWay = hit
-							selectedRelation = nil
-						}
+					} else if let relation = EditorMapLayer.relationToPromote(
+						parentRelations: hit.parentRelations,
+						wayHasInterestingTags: hit.hasInterestingTags())
+					{
+						// promote to the containing relation (multipolygon, boundary, etc.)
+						selectedNode = nil
+						selectedWay = nil
+						selectedRelation = relation
 					} else {
 						selectedNode = nil
 						selectedWay = hit
@@ -219,6 +209,27 @@ extension EditorMapLayer {
 				dragState.confirmDrag = selectedPrimary.modifyCount == 0
 			}
 		}
+	}
+
+	/// Decide whether a tapped way should be promoted to one of its parent relations instead of
+	/// being selected directly.
+	/// A way that carries its own interesting tags is never auto-promoted (the user tapped a real
+	/// feature, e.g. amenity=parking, and should select the way itself); the parent relation stays
+	/// reachable from the way's Relations list. A tag-less member way still promotes to its
+	/// containing multipolygon/boundary/waterway, or to any parent relation if it has no container.
+	static func relationToPromote(parentRelations: [OsmRelation],
+	                              wayHasInterestingTags: Bool) -> OsmRelation?
+	{
+		if parentRelations.isEmpty || wayHasInterestingTags {
+			return nil
+		}
+		let containers = parentRelations.filter { relation in
+			relation.isMultipolygon() || relation.isBoundary() || relation.isWaterway()
+		}
+		// Choose deterministically by id: parentRelations comes from a dictionary-ordered cache,
+		// so a way shared by several relations must still promote to the same one across launches.
+		let pool = containers.isEmpty ? parentRelations : containers
+		return pool.min(by: { $0.ident < $1.ident })
 	}
 
 	// MARK: Dragging pushPin

--- a/src/Shared/EditorLayer/EditorMapLayer+HitTest.swift
+++ b/src/Shared/EditorLayer/EditorMapLayer+HitTest.swift
@@ -183,10 +183,13 @@ extension EditorMapLayer {
 			return nil
 		}
 
+		// Order the candidate set once, so both drag-connect and tap selection (and the fallback)
+		// resolve equal-distance ties the same way across taps and app launches.
+		let candidates = EditorMapLayer.sortedForSelection(Array(best.keys))
 		var pick: OsmBaseObject?
 		if isDragConnect {
 			// prefer to connecct to a way in a relation over the relation itself, which is opposite what we do when selecting by tap
-			for obj in best.keys {
+			for obj in candidates {
 				if obj.isRelation() == nil {
 					pick = obj
 					break
@@ -194,35 +197,90 @@ extension EditorMapLayer {
 			}
 		} else {
 			// performing selection by tap
-			if pick == nil,
-			   let relation = selectedRelation
-			{
-				// pick a way that is a member of the relation if possible
-				for member in relation.members {
-					if let obj = member.obj,
-					   best[obj] != nil
-					{
-						pick = obj
-						break
-					}
-				}
-			}
-			if pick == nil, selectedPrimary == nil {
-				// nothing currently selected, so prefer relations
-				for obj in best.keys {
-					if obj.isRelation() != nil {
-						pick = obj
-						break
-					}
-				}
-			}
+			pick = EditorMapLayer.tapSelectionPick(among: candidates,
+			                                       selectedRelation: selectedRelation,
+			                                       hasExistingSelection: selectedPrimary != nil)
 		}
 		if pick == nil {
-			pick = best.first!.key
+			pick = candidates.first
 		}
 		guard let pick = pick else { return nil }
 		pSegment = best[pick]!
 		return pick
+	}
+
+	/// Among the equally-close hit-test candidates, decide which object a tap should select.
+	/// - When a relation is already selected we prefer one of its member ways, so successive
+	///   taps drill down relation -> way -> node.
+	/// - A way that carries its own interesting tags and is a member of one of the candidate
+	///   *container* relations (multipolygon/boundary/waterway, e.g. a parking area that is also a
+	///   multipolygon member) is preferred over that relation, so the user selects the feature they
+	///   see rather than its container (#969). Scoped to container members so an unrelated tagged
+	///   way never steals a relation's selection and route/turn-restriction members don't either;
+	///   it applies regardless of the current selection.
+	/// - Otherwise, when nothing is selected we prefer a relation (a container relation first),
+	///   so multipolygons/boundaries with tag-less member ways remain selectable on the first tap.
+	/// Candidates are visited in a stable id order so equal-distance ties resolve the same way
+	/// across taps and app launches.
+	static func tapSelectionPick(among candidates: [OsmBaseObject],
+	                             selectedRelation: OsmRelation?,
+	                             hasExistingSelection: Bool) -> OsmBaseObject?
+	{
+		// Sorted here too so the helper is deterministic in isolation (callers may already sort).
+		let candidates = EditorMapLayer.sortedForSelection(candidates)
+
+		// Drilling down: prefer a member way of the already-selected relation.
+		if let relation = selectedRelation {
+			for member in relation.members {
+				if let obj = member.obj, candidates.contains(obj) {
+					return obj
+				}
+			}
+		}
+
+		// Container relations under the tap (multipolygon/boundary/waterway). These are the only
+		// relations a tagged member should be preferred over: routes/turn-restrictions etc. have
+		// no geometry of their own, so their member ways must not steal their selection. This
+		// scoping matches relationToPromote.
+		let containerRelations = candidates
+			.compactMap { $0 as? OsmRelation }
+			.filter { $0.isMultipolygon() || $0.isBoundary() || $0.isWaterway() }
+
+		// A tagged way that is a member of a candidate container relation selects the way itself
+		// rather than its container (#969).
+		for obj in candidates {
+			if let way = obj as? OsmWay,
+			   way.hasInterestingTags(),
+			   containerRelations.contains(where: { $0.member(byRef: way) != nil })
+			{
+				return way
+			}
+		}
+
+		// Nothing selected: prefer a relation so tag-less members don't hijack the first tap away
+		// from their container. Prefer a container relation (as relationToPromote does), then any.
+		if !hasExistingSelection {
+			if let container = containerRelations.first {
+				return container
+			}
+			for obj in candidates {
+				if obj.isRelation() != nil {
+					return obj
+				}
+			}
+		}
+
+		// Deterministic fallback over the equal-distance set.
+		return candidates.first
+	}
+
+	/// Stable ordering of hit-test candidates by OSM id, so equal-distance ties resolve the same
+	/// way across taps and app launches.
+	static func sortedForSelection(_ candidates: [OsmBaseObject]) -> [OsmBaseObject] {
+		candidates.sorted {
+			($0.extendedIdentifier.ident, $0.extendedIdentifier.type.rawValue)
+				< ($1.extendedIdentifier.ident, $1.extendedIdentifier.type.rawValue)
+		}
 	}
 
 	// return all nearby objects

--- a/src/iOS/Go Map!!.xcodeproj/project.pbxproj
+++ b/src/iOS/Go Map!!.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 		64348CFE225E867800ADE7FB /* MeasureDirectionViewModelTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64348CFA225E867800ADE7FB /* MeasureDirectionViewModelTestCase.swift */; };
 		64348D01225E8D3F00ADE7FB /* OsmNode+Direction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64348D00225E8D3F00ADE7FB /* OsmNode+Direction.swift */; };
 		64348D03225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64348D02225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift */; };
+		FA0969F100000000000969F1 /* EditorMapLayerSelectionTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0969F200000000000969F2 /* EditorMapLayerSelectionTestCase.swift */; };
 		64348D13225EAA5D00ADE7FB /* MapViewUITestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64348D12225EAA5D00ADE7FB /* MapViewUITestCase.swift */; };
 		6442666722540EDF00C0D545 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6442666422540EDF00C0D545 /* Lock.swift */; };
 		6442666822540EDF00C0D545 /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6442666522540EDF00C0D545 /* Disposable.swift */; };
@@ -595,6 +596,7 @@
 		64348CFA225E867800ADE7FB /* MeasureDirectionViewModelTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeasureDirectionViewModelTestCase.swift; sourceTree = "<group>"; };
 		64348D00225E8D3F00ADE7FB /* OsmNode+Direction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OsmNode+Direction.swift"; sourceTree = "<group>"; };
 		64348D02225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OsmNode_DirectionTestCase.swift; sourceTree = "<group>"; };
+		FA0969F200000000000969F2 /* EditorMapLayerSelectionTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorMapLayerSelectionTestCase.swift; sourceTree = "<group>"; };
 		64348D08225EA24E00ADE7FB /* GoMapUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GoMapUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		64348D0C225EA24E00ADE7FB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		64348D12225EAA5D00ADE7FB /* MapViewUITestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewUITestCase.swift; sourceTree = "<group>"; };
@@ -1193,6 +1195,7 @@
 				64348CFA225E867800ADE7FB /* MeasureDirectionViewModelTestCase.swift */,
 				64348CF6225E867800ADE7FB /* Mocks */,
 				64348D02225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift */,
+				FA0969F200000000000969F2 /* EditorMapLayerSelectionTestCase.swift */,
 				64348CEC225E7CD900ADE7FB /* GoMapTests.swift */,
 				64C072FC22622B9C00598078 /* Vendor */,
 				64348CEE225E7CD900ADE7FB /* Info.plist */,
@@ -1821,6 +1824,7 @@
 				64E21EB822651F2D004605D7 /* XCTestCase+UserDefaults.swift in Sources */,
 				64348CFD225E867800ADE7FB /* CLHeadingMock.swift in Sources */,
 				64348D03225E8E4300ADE7FB /* OsmNode_DirectionTestCase.swift in Sources */,
+				FA0969F100000000000969F1 /* EditorMapLayerSelectionTestCase.swift in Sources */,
 				64E21EB522651C06004605D7 /* OSMMapDataTestCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/iOS/GoMapTests/EditorMapLayerSelectionTestCase.swift
+++ b/src/iOS/GoMapTests/EditorMapLayerSelectionTestCase.swift
@@ -1,0 +1,183 @@
+//
+//  EditorMapLayerSelectionTestCase.swift
+//  GoMapTests
+//
+//  Tests the tap-selection decision logic that determines whether a tapped way is
+//  selected directly or promoted to a containing relation.
+//  Regression coverage for issue #969 ("Shows parking as managed forest"): a parking
+//  area that is also a member of a forest multipolygon should select as the parking
+//  on the first tap, not as the forest relation.
+//
+
+@testable import Go_Map__
+import XCTest
+
+final class EditorMapLayerSelectionTestCase: XCTestCase {
+	private func makeWay(tags: [String: String]) -> OsmWay {
+		let way = OsmWay(asUserCreated: "test")
+		way.setTags(tags, undo: nil)
+		return way
+	}
+
+	private func makeRelation(tags: [String: String], members: [OsmBaseObject] = []) -> OsmRelation {
+		let relation = OsmRelation(asUserCreated: "test")
+		relation.setTags(tags, undo: nil)
+		for (index, obj) in members.enumerated() {
+			relation.addMember(OsmMember(obj: obj, role: "outer"), atIndex: index, undo: nil)
+		}
+		return relation
+	}
+
+	// MARK: relationToPromote
+
+	/// #969: a parking way that is a member of a forest multipolygon must NOT promote to the
+	/// forest, so the user selects the parking on the first tap.
+	func testTaggedWayInMultipolygonIsNotPromoted() {
+		let forest = makeRelation(tags: ["type": "multipolygon", "landuse": "forest"])
+		XCTAssertTrue(forest.isMultipolygon())
+		let result = EditorMapLayer.relationToPromote(parentRelations: [forest],
+		                                              wayHasInterestingTags: true)
+		XCTAssertNil(result, "a way with its own interesting tags should select the way, not the relation")
+	}
+
+	/// A tag-less member way (the common multipolygon ring) still promotes to its container.
+	func testTaglessWayInMultipolygonStillPromotes() {
+		let forest = makeRelation(tags: ["type": "multipolygon", "landuse": "forest"])
+		let result = EditorMapLayer.relationToPromote(parentRelations: [forest],
+		                                              wayHasInterestingTags: false)
+		XCTAssertEqual(result, forest)
+	}
+
+	/// A way with no parent relations is never promoted.
+	func testWayWithoutParentsIsNotPromoted() {
+		XCTAssertNil(EditorMapLayer.relationToPromote(parentRelations: [],
+		                                              wayHasInterestingTags: false))
+		XCTAssertNil(EditorMapLayer.relationToPromote(parentRelations: [],
+		                                              wayHasInterestingTags: true))
+	}
+
+	/// A tag-less way whose only parent is a non-container relation (e.g. a route) still
+	/// promotes to that parent, matching the prior behavior.
+	func testTaglessWayPromotesToNonContainerParent() {
+		let route = makeRelation(tags: ["type": "route", "route": "bicycle"])
+		XCTAssertFalse(route.isMultipolygon())
+		let result = EditorMapLayer.relationToPromote(parentRelations: [route],
+		                                              wayHasInterestingTags: false)
+		XCTAssertEqual(result, route)
+	}
+
+	// MARK: tapSelectionPick
+
+	/// First tap with nothing selected prefers the tagged way over its containing relation.
+	func testTapPrefersTaggedWayOverContainingRelation() {
+		let parking = makeWay(tags: ["amenity": "parking"])
+		let forest = makeRelation(tags: ["type": "multipolygon", "landuse": "forest"], members: [parking])
+		let pick = EditorMapLayer.tapSelectionPick(among: [parking, forest],
+		                                           selectedRelation: nil,
+		                                           hasExistingSelection: false)
+		XCTAssertTrue(pick === parking)
+	}
+
+	/// First tap with nothing selected prefers the relation when the candidate way is tag-less.
+	func testTapPrefersRelationWhenWayIsTagless() {
+		let ring = makeWay(tags: [:])
+		let forest = makeRelation(tags: ["type": "multipolygon", "landuse": "forest"], members: [ring])
+		let pick = EditorMapLayer.tapSelectionPick(among: [ring, forest],
+		                                           selectedRelation: nil,
+		                                           hasExistingSelection: false)
+		XCTAssertTrue(pick === forest)
+	}
+
+	/// Drill-down: with a relation already selected, a re-tap prefers a member way of it.
+	func testTapDrillsFromSelectedRelationToMemberWay() {
+		let parking = makeWay(tags: ["amenity": "parking"])
+		let forest = makeRelation(tags: ["type": "multipolygon", "landuse": "forest"], members: [parking])
+		let pick = EditorMapLayer.tapSelectionPick(among: [parking, forest],
+		                                           selectedRelation: forest,
+		                                           hasExistingSelection: true)
+		XCTAssertTrue(pick === parking)
+	}
+
+	/// With an existing selection and a single candidate, the deterministic fallback returns
+	/// that candidate (rather than deferring to the caller's nondeterministic tiebreak).
+	func testTapFallsBackToSoleCandidateWhenSelectionExists() {
+		let parking = makeWay(tags: ["amenity": "parking"])
+		let pick = EditorMapLayer.tapSelectionPick(among: [parking],
+		                                           selectedRelation: nil,
+		                                           hasExistingSelection: true)
+		XCTAssertTrue(pick === parking)
+	}
+
+	/// A tagged way that is NOT a member of the candidate relation must not steal the relation's
+	/// first-tap selection (the relation must remain selectable).
+	func testTapDoesNotStealRelationForUnrelatedTaggedWay() {
+		let footway = makeWay(tags: ["highway": "footway"])
+		let forest = makeRelation(tags: ["type": "multipolygon", "landuse": "forest"]) // footway is not a member
+		let pick = EditorMapLayer.tapSelectionPick(among: [footway, forest],
+		                                           selectedRelation: nil,
+		                                           hasExistingSelection: false)
+		XCTAssertTrue(pick === forest)
+	}
+
+	/// The tagged-member preference applies even when something else is already selected, so
+	/// the #969 fix is not limited to a fresh tap.
+	func testTapPrefersTaggedMemberEvenWhenSelectionExists() {
+		let parking = makeWay(tags: ["amenity": "parking"])
+		let forest = makeRelation(tags: ["type": "multipolygon", "landuse": "forest"], members: [parking])
+		let pick = EditorMapLayer.tapSelectionPick(among: [parking, forest],
+		                                           selectedRelation: nil,
+		                                           hasExistingSelection: true)
+		XCTAssertTrue(pick === parking)
+	}
+
+	/// Equal-distance ties resolve deterministically regardless of candidate input order.
+	func testTapSelectionIsOrderIndependent() {
+		let wayA = makeWay(tags: ["amenity": "parking"])
+		let wayB = makeWay(tags: ["amenity": "parking"])
+		let forest = makeRelation(tags: ["type": "multipolygon", "landuse": "forest"], members: [wayA, wayB])
+		let pick1 = EditorMapLayer.tapSelectionPick(among: [wayA, wayB, forest],
+		                                            selectedRelation: nil,
+		                                            hasExistingSelection: false)
+		let pick2 = EditorMapLayer.tapSelectionPick(among: [forest, wayB, wayA],
+		                                            selectedRelation: nil,
+		                                            hasExistingSelection: false)
+		XCTAssertTrue(pick1 === pick2)
+		XCTAssertTrue(pick1 === wayA || pick1 === wayB)
+	}
+
+	/// A tagged member of a NON-container relation (route, turn-restriction) must NOT win over the
+	/// relation: such relations have no geometry of their own and are only reachable by tapping a
+	/// member, so the relation must be selectable on the first tap.
+	func testTapDoesNotPreferTaggedMemberOfNonContainerRelation() {
+		let road = makeWay(tags: ["highway": "path"])
+		let route = makeRelation(tags: ["type": "route", "route": "hiking"], members: [road])
+		let pick = EditorMapLayer.tapSelectionPick(among: [road, route],
+		                                           selectedRelation: nil,
+		                                           hasExistingSelection: false)
+		XCTAssertTrue(pick === route)
+	}
+
+	/// When a tag-less way ties with both a non-container relation and a container relation, the
+	/// container is preferred (matching relationToPromote), deterministically.
+	func testTapPrefersContainerRelationOverNonContainer() {
+		let ring = makeWay(tags: [:])
+		let route = makeRelation(tags: ["type": "route", "route": "hiking"], members: [ring])
+		let forest = makeRelation(tags: ["type": "multipolygon", "landuse": "forest"], members: [ring])
+		let pick = EditorMapLayer.tapSelectionPick(among: [ring, route, forest],
+		                                           selectedRelation: nil,
+		                                           hasExistingSelection: false)
+		XCTAssertTrue(pick === forest)
+	}
+
+	/// relationToPromote chooses the same container regardless of parentRelations order.
+	func testRelationToPromoteIsDeterministicAmongContainers() {
+		let mp1 = makeRelation(tags: ["type": "multipolygon", "landuse": "forest"])
+		let mp2 = makeRelation(tags: ["type": "multipolygon", "natural": "wood"])
+		let pick1 = EditorMapLayer.relationToPromote(parentRelations: [mp1, mp2],
+		                                             wayHasInterestingTags: false)
+		let pick2 = EditorMapLayer.relationToPromote(parentRelations: [mp2, mp1],
+		                                             wayHasInterestingTags: false)
+		XCTAssertNotNil(pick1)
+		XCTAssertTrue(pick1 === pick2)
+	}
+}


### PR DESCRIPTION
Fixes #969.

## Problem

Tapping a parking area that is also an `inner` member of a `landuse=forest` multipolygon selects the forest relation first, so the app shows "Managed Forest" instead of "Parking" (see #969). The drill-down model (relation → way → node) always promotes a tapped member way to its containing relation, even when the way carries its own feature tags.

## Change

A member way that has its own interesting tags (e.g. `amenity=parking`) and is a member of a multipolygon/boundary/waterway relation now selects the **way** itself on the first tap, instead of promoting to the container. Tag-less member ways (ordinary multipolygon rings) still promote, so multipolygons and boundaries remain selectable on the first tap. The parent relation stays reachable from the selected way's Relations list.

The two selection decisions are extracted into pure, unit-testable helpers:

- `tapSelectionPick(...)` in `EditorMapLayer+HitTest.swift`: among equally-close hit-test candidates, prefer a tagged way that is a member of one of the candidate container relations (multipolygon/boundary/waterway); otherwise, when nothing is selected, prefer a relation (a container first). Candidates are visited in a stable id order so equal-distance ties resolve deterministically.
- `relationToPromote(...)` in `EditorMapLayer+Edit.swift`: a tagged way is no longer auto-promoted to its container; tag-less members still promote, chosen deterministically.

## Tradeoff (worth a maintainer's eye)

This is a heuristic, in the spirit of iD's "select what is rendered on top". The cost: for a tagged member way, the parent relation is no longer reachable by repeated tapping, only via the selected way's Relations list. A more complete alternative would be a disambiguation prompt on an ambiguous tap (the candidates are already available via `osmHitTestMultiple`), which preserves tap-to-relation at the cost of an extra choice. Happy to take it that direction if you prefer.

## Tests

Adds `EditorMapLayerSelectionTestCase` covering: the #969 case, tag-less members still promoting, an unrelated tagged way not stealing a relation's selection, members of non-container relations (routes/turn-restrictions) not stealing selection, container relations preferred over non-containers, the preference applying regardless of the current selection, and order-independent (deterministic) tie-breaking. Full test suite green (55 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
