### PR TITLE
Fix Tags table scroll staying disabled after backgrounding

### DIFF
--- a/src/iOS/CustomViews/AutocompleteTextField.swift
+++ b/src/iOS/CustomViews/AutocompleteTextField.swift
@@ -33,6 +33,11 @@ class AutocompleteTextField: UITextField, UITableViewDataSource, UITableViewDele
 			selector: #selector(keyboardWillChange(_:)),
 			name: UIResponder.keyboardWillChangeFrameNotification,
 			object: nil)
+		NotificationCenter.default.addObserver(
+			self,
+			selector: #selector(appWillResignActive(_:)),
+			name: UIApplication.willResignActiveNotification,
+			object: nil)
 
 		addTarget(self, action: #selector(editingChanged), for: .editingChanged)
 		addTarget(self, action: #selector(editingEnded), for: .editingDidEnd)
@@ -119,6 +124,12 @@ class AutocompleteTextField: UITextField, UITableViewDataSource, UITableViewDele
 		if isEditing, filteredCompletions.count != 0 {
 			updateAutocomplete()
 		}
+	}
+
+	@objc func appWillResignActive(_ nsNotification: Notification) {
+		guard !filteredCompletions.isEmpty else { return }
+
+		clearFilteredCompletionsInternal()
 	}
 
 	func frameForCompletionTableView() -> CGRect {
@@ -256,6 +267,15 @@ class AutocompleteTextField: UITextField, UITableViewDataSource, UITableViewDele
 
 	@objc private func editingEnded() {
 		clearFilteredCompletionsInternal()
+
+		// Defensively restore scrolling: if the overlay teardown path was
+		// skipped (e.g. the app resigned active while completions showed),
+		// the enclosing table would otherwise stay unscrollable.
+		if let cell = superviewOfType(UITableViewCell.self),
+		   let tableView = cell.superviewOfType(UITableView.self)
+		{
+			tableView.isScrollEnabled = true
+		}
 	}
 
 	override func paste(_ sender: Any?) {


### PR DESCRIPTION
## What

Fixes the POI tag tables (Common Tags and All Tags) becoming permanently unscrollable, as reported when switching to another app mid-edit and coming back.

## Why

When the autocomplete completion overlay appears on iOS 26+, `AutocompleteTextField` sets the enclosing table view's `isScrollEnabled = false` so the overlay owns scrolling. That flag is only restored to `true` in the overlay teardown branch of `updateCompletionTableView()`.

If the app resigns active (for example switching to Safari) while the overlay is showing, the field can lose its editing state without the teardown path ever running, so the Tags table is left stuck at `isScrollEnabled = false` and never scrolls again. That matches the reported repro of switching to Safari and back.

## Change

- Dismiss the completion overlay on `UIApplication.willResignActiveNotification` (registered alongside the existing keyboard observers, removed by the existing `deinit`), so scrolling is restored before the app backgrounds. The handler is guarded on `filteredCompletions` being non-empty, so fields without an active overlay do nothing and inactive tables are not disturbed when the app switcher or control center is opened.
- Defensively re-enable the enclosing table view's scrolling in `textFieldDidEndEditing` as a belt-and-suspenders restore.

The fix is confined to `AutocompleteTextField.swift`, the only place that disables the parent table's scrolling.

Fixes #867
